### PR TITLE
新增 ChatGPT 订阅（Plus/Pro）用量展示：支持插件内设备码登录与 Codex CLI 两种方式

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ quota is left — DeepSeek, OpenRouter, SiliconFlow, Moonshot, StepFun,
 xAI, Zhipu GLM, OpenCode Go, Volcengine Ark (Agent/Coding Plan), plus one-api / new-api style aggregators,
 and the **coding plans** (智谱 GLM Coding, Z.AI, Kimi Coding, MiniMax
 Coding global/CN) with 5-hour / weekly usage windows and MCP monthly quota.
+xAI, Zhipu GLM, OpenCode Go, **ChatGPT subscription (Plus/Pro via Codex
+login)**, plus one-api / new-api style aggregators, and the **coding
+plans** (智谱 GLM Coding, Z.AI, Kimi Coding, MiniMax Coding global/CN)
+with 5-hour / weekly usage windows and MCP monthly quota.
 
 Since v0.5 it is a **dual-face plugin** with a **built-in provider catalog
 and auto discovery**: install it, restart `dsh web`, and every provider
@@ -308,6 +312,7 @@ After restart, check the panel:
 > Redact it before pasting into chats, tickets, or screenshots, and rotate it
 > from the [key management page](https://console.volcengine.com/iam/keymanage)
 > when no longer needed.
+| ChatGPT subscription (Plus/Pro) | `~/.codex/auth.json` (Codex login; no API key) | `chatgpt.com/backend-api/wham/usage` | weekly usage % (Pro includes a 5h window) |
 
 An additional **`openai-billing`** format adapts one-api / new-api style
 aggregators: set `endpoint` to the aggregator base URL and the host half
@@ -341,6 +346,40 @@ The currency symbol for balance-kind rows comes from the format by default
 rows carry `currency` (the global SiliconFlow row sets `$`), a `catalog:`
 override may set it, and explicit `providers:` entries accept a `currency`
 field (e.g. `"US$"`).
+
+### ChatGPT subscription (Plus/Pro)
+
+ChatGPT subscription usage is **not** API billing — there is no public
+balance/usage API. This plugin reads the ChatGPT OAuth token from
+`~/.codex/auth.json` (written when you log in via the open-source Codex CLI),
+calls the same internal usage endpoint Codex uses, and shows the **weekly
+window** (and the **5-hour window** on Pro) as a used-percentage row.
+
+> ⚠️ **Experimental.** The endpoint (`chatgpt.com/backend-api/wham/usage`) is
+> an undocumented internal API used by the Codex CLI; its response shape may
+> change. The plugin only performs read-only queries and never modifies your
+> Codex configuration.
+
+**Setup:**
+
+1. Install and log in to the Codex CLI any way you like
+   (`npm i -g @openai/codex`, then run `codex` and complete the ChatGPT login
+   in your browser). This creates `~/.codex/auth.json`;
+2. No key in `.credentials.yaml` is needed — the plugin auto-detects
+   `auth.json` and shows the ChatGPT row whenever it exists;
+3. Restart `dsh web`. A "ChatGPT" row appears; hover to see `plan: plus/pro`
+   and `weekly: N%` (Pro also shows a 5h window).
+
+How it works: when the access token expires, the plugin refreshes it via
+`auth.openai.com/oauth/token` using the refresh token in `auth.json`. Refreshed
+tokens stay in the plugin process memory only and are **never written back** to
+`auth.json` (that file is owned by the Codex CLI). If refresh fails (e.g. you
+logged in elsewhere and invalidated the token), the row shows an error — just
+run `codex` to log in again and it recovers.
+
+If the `CODEX_HOME` environment variable points at a custom directory, the
+plugin reads from `$CODEX_HOME/auth.json`.
+
 ### Built-in formats
 
 | format | Row kind | Upstream response shape |
@@ -358,6 +397,7 @@ field (e.g. `"US$"`).
 | `zai-coding-quota` | usage % | `{ code: 200, data: { limits: [{ type: TOKENS_LIMIT \| TIME_LIMIT, unit, number, percentage, currentValue, usage, nextResetTime }] } }` — semantic mapping (glm-plan-usage2, issue #2): TOKENS_LIMIT `unit=3` → 5h window, `unit=6` → weekly, TIME_LIMIT → MCP monthly lane; unknown units fall back to `nextResetTime` ordering; every window prefers the `percentage` field |
 | `kimi-coding-usage` | usage % | `{ usage: { limit, used, remaining, resetTime }, limits: [{ window: { duration, timeUnit }, detail: { limit, used, remaining, resetTime } }] }` — 5h = the `duration=300` window, weekly = `duration=10080` (fallback: top-level usage); used = limit − remaining |
 | `volcengine-usage` | usage % | Dispatched inline in `fetchRow` (not through `adaptRow`): signs and calls the Volcengine Ark OpenAPI `GetAFPUsage`, then falls back to `GetCodingPlanUsage`. Agent Plan parses `Result.AFPFiveHour / AFPWeekly / AFPMonthly` (AFPDaily skipped per the console). Coding Plan parses `Result.QuotaUsage[].Level ∈ {session,weekly,monthly}` (percentages only). |
+| `chatgpt-subscription` | usage % | `{ plan_type, rate_limit: { primary_window: { used_percent, reset_at }, secondary_window? } }` — read via the OAuth token in `~/.codex/auth.json` against Codex's internal usage endpoint; primary maps to the weekly window, secondary (Pro) to the 5h window. Experimental |
 
 ### Proxy (providers that cannot be reached directly)
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ After restart, check the panel:
 > Redact it before pasting into chats, tickets, or screenshots, and rotate it
 > from the [key management page](https://console.volcengine.com/iam/keymanage)
 > when no longer needed.
-| ChatGPT subscription (Plus/Pro) | `~/.codex/auth.json` (Codex login; no API key) | `chatgpt.com/backend-api/wham/usage` | weekly usage % (Pro includes a 5h window) |
+| ChatGPT subscription (Plus/Pro) | in-plugin login or `~/.codex/auth.json` (no API key) | `chatgpt.com/backend-api/wham/usage` | weekly usage % (Pro includes a 5h window) |
 
 An additional **`openai-billing`** format adapts one-api / new-api style
 aggregators: set `endpoint` to the aggregator base URL and the host half
@@ -350,35 +350,45 @@ field (e.g. `"US$"`).
 ### ChatGPT subscription (Plus/Pro)
 
 ChatGPT subscription usage is **not** API billing — there is no public
-balance/usage API. This plugin reads the ChatGPT OAuth token from
-`~/.codex/auth.json` (written when you log in via the open-source Codex CLI),
-calls the same internal usage endpoint Codex uses, and shows the **weekly
-window** (and the **5-hour window** on Pro) as a used-percentage row.
+balance/usage API. This plugin calls the same internal usage endpoint Codex
+uses, with a ChatGPT OAuth token, and shows the **weekly window** (and the
+**5-hour window** on Pro) as a used-percentage row. **Two login methods are
+supported**, pick whichever you prefer:
 
 > ⚠️ **Experimental.** The endpoint (`chatgpt.com/backend-api/wham/usage`) is
 > an undocumented internal API used by the Codex CLI; its response shape may
-> change. The plugin only performs read-only queries and never modifies your
-> Codex configuration.
+> change. The plugin only performs read-only queries.
 
-**Setup:**
+#### Option A: in-plugin login (recommended — no Codex CLI install required)
 
-1. Install and log in to the Codex CLI any way you like
-   (`npm i -g @openai/codex`, then run `codex` and complete the ChatGPT login
-   in your browser). This creates `~/.codex/auth.json`;
-2. No key in `.credentials.yaml` is needed — the plugin auto-detects
-   `auth.json` and shows the ChatGPT row whenever it exists;
-3. Restart `dsh web`. A "ChatGPT" row appears; hover to see `plan: plus/pro`
-   and `weekly: N%` (Pro also shows a 5h window).
+1. Restart `dsh web` and open the panel **settings** (gear icon) in the
+   bottom-right corner;
+2. In the "ChatGPT account" section at the top, click **"Log in to ChatGPT"**;
+3. The plugin starts an OAuth device-code flow and displays a **one-time code**
+   plus the sign-in URL `https://auth.openai.com/codex/device`;
+4. Open the URL in your browser, sign in with your ChatGPT Plus/Pro account,
+   and enter the code;
+5. Once authorized, a "ChatGPT" row appears automatically (no restart). Hover
+   to see `plan: plus/pro` and `weekly: N%` (Pro also shows a 5h window).
 
-How it works: when the access token expires, the plugin refreshes it via
-`auth.openai.com/oauth/token` using the refresh token in `auth.json`. Refreshed
-tokens stay in the plugin process memory only and are **never written back** to
-`auth.json` (that file is owned by the Codex CLI). If refresh fails (e.g. you
-logged in elsewhere and invalidated the token), the row shows an error — just
-run `codex` to log in again and it recovers.
+Tokens are stored in `$DSH_HOME/dsh-quota-panel/chatgpt-auth.json`
+(`C:\Users\<you>\.dsh\dsh-quota-panel\` on Windows, file mode 0600). When the
+access token expires the plugin refreshes it with the refresh token and writes
+it back. Click "Log out" in the same section to delete the local token.
 
-If the `CODEX_HOME` environment variable points at a custom directory, the
-plugin reads from `$CODEX_HOME/auth.json`.
+#### Option B: reuse a Codex CLI login
+
+If you have already logged in via the [Codex CLI](https://developers.openai.com/codex/)
+(ran `codex` and completed the browser sign-in), the plugin automatically reads
+`~/.codex/auth.json` (or `$CODEX_HOME/auth.json`) — **no extra configuration
+needed**. With this method, refreshed tokens stay in the plugin process memory
+only and are **never written back** to `auth.json` (that file is owned by the
+Codex CLI).
+
+When both are present, the **in-plugin login takes precedence**. When neither
+exists the ChatGPT row is hidden. If the token is invalidated by a login
+elsewhere, the row shows an error — run Option A again, or `codex login`, to
+recover.
 
 ### Built-in formats
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -248,7 +248,7 @@ VOLC_SECRET_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 - 显示 `No active Agent Plan or Coding Plan subscription` → 签名通过但该账号没有订阅 Agent/Coding Plan（按量付费账号就会这样，面板上可以在 ⚙ 设置里隐藏这一行）。
 
 > 安全建议：AK/SK 一旦泄露他人可以读你方舟账号的所有用量数据，贴到聊天/工单/截图前先打码；不再用时去 [密钥管理页](https://console.volcengine.com/iam/keymanage) 禁用并轮换。
-| ChatGPT 订阅（Plus/Pro） | `~/.codex/auth.json`（Codex 登录，无需 API Key） | `chatgpt.com/backend-api/wham/usage` | 周用量%（Pro 含 5h 窗口） |
+| ChatGPT 订阅（Plus/Pro） | 插件内登录 或 `~/.codex/auth.json`（无需 API Key） | `chatgpt.com/backend-api/wham/usage` | 周用量%（Pro 含 5h 窗口） |
 
 另内置 **`openai-billing`** 格式，适配 one-api / new-api 等聚合站：`endpoint` 配
 聚合站 base URL，宿主侧请求 `{base}/v1/dashboard/billing/subscription`
@@ -282,31 +282,37 @@ VOLC_SECRET_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ### ChatGPT 订阅（Plus/Pro）接入
 
 ChatGPT 订阅用量**不是 API 计费**，没有公开的余额/用量 API。本插件通过
-官方开源 Codex CLI 登录后写入的 `~/.codex/auth.json`，读取 ChatGPT OAuth
-令牌，调用 Codex 同款的内部用量端点，把 Plus/Pro 套餐的**周窗口（及 Pro
-的 5 小时窗口）已用百分比**显示在面板上。
+ChatGPT OAuth 令牌调用 Codex 同款的内部用量端点，把 Plus/Pro 套餐的**周窗口
+（及 Pro 的 5 小时窗口）已用百分比**显示在面板上。支持**两种登录方式**，
+任选其一：
 
 > ⚠️ **实验性（experimental）**：该端点（`chatgpt.com/backend-api/wham/usage`）
 > 是 Codex CLI 内部使用的未公开接口，响应字段可能随官方调整而变化。本插件
-> 只做只读查询，不会写入或修改你的 Codex 配置。
+> 只做只读查询。
 
-**接入步骤：**
+#### 方式 A：插件内登录（推荐，无需安装 Codex CLI）
 
-1. 安装并登录 Codex CLI（任意方式：`npm i -g @openai/codex` 后运行 `codex`，
-   在浏览器完成 ChatGPT 登录）。登录会生成 `~/.codex/auth.json`；
-2. 无需在 `.credentials.yaml` 里配置任何 Key——插件自动探测 `auth.json`，
-   存在就显示 ChatGPT 行；
-3. 重启 `dsh web`。面板出现「ChatGPT」行，悬停可见 `plan: plus/pro` 与
-   `weekly: N%`（Pro 还会有 5h 窗口）。
+1. 重启 `dsh web`，打开右下角面板的**设置**（齿轮图标）；
+2. 在最上方「ChatGPT 账号」一栏点「**登录 ChatGPT**」；
+3. 插件会调起设备码（device-code）流程，设置里显示一个**一次性验证码**和
+   登录链接 `https://auth.openai.com/codex/device`；
+4. 在浏览器打开链接、登录你的 ChatGPT Plus/Pro 账号并输入验证码；
+5. 授权完成后面板自动出现「ChatGPT」行（无需重启），悬停可见
+   `plan: plus/pro` 与 `weekly: N%`（Pro 还会有 5h 窗口）。
 
-工作机制：access token 过期时，插件用 `auth.json` 里的 refresh token 向
-`auth.openai.com/oauth/token` 自动刷新；刷新后的令牌仅保存在插件进程内存中，
-**不会回写** `auth.json`（该文件归 Codex CLI 所有）。若 refresh 也失败
-（例如在别处重新登录导致令牌失效），面板会显示错误，重新运行一次 `codex`
-登录即可恢复。
+令牌保存在 `$DSH_HOME/dsh-quota-panel/chatgpt-auth.json`（Windows 即
+`C:\Users\<你>\.dsh\dsh-quota-panel\`，文件权限 0600），access token 过期时
+插件用 refresh token 自动刷新并回写。点同一栏的「退出登录」即可删除本地令牌。
 
-如果 `CODEX_HOME` 环境变量指向了自定义目录，插件会从
-`$CODEX_HOME/auth.json` 读取。
+#### 方式 B：复用 Codex CLI 登录
+
+如果你已经用 [Codex CLI](https://developers.openai.com/codex/) 登录过（运行
+`codex` 完成浏览器授权），插件会自动读取 `~/.codex/auth.json`（或
+`$CODEX_HOME/auth.json`），**无需任何额外配置**。此方式下刷新后的令牌只留在
+插件进程内存，**不会回写** `auth.json`（该文件归 Codex CLI 所有）。
+
+两种方式同时存在时，**插件内登录的令牌优先**；都没有时 ChatGPT 行不显示。
+若令牌在别处被重新登录而失效，面板会提示，重新走一次方式 A 或 `codex` 登录即可恢复。
 
 ### 内置 format
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,6 +8,10 @@
 StepFun、xAI、智谱 GLM、OpenCode Go、火山方舟（Agent/Coding Plan），one-api / new-api 风格的聚合站，
 以及各家 **Coding Plan**（智谱 GLM Coding、Z.AI、Kimi Coding、MiniMax
 Coding 国际/国内）：5 小时窗口、周配额与 MCP 月度额度一目了然。
+StepFun、xAI、智谱 GLM、OpenCode Go、**ChatGPT 订阅（Plus/Pro，经 Codex 登录）**，
+one-api / new-api 风格的聚合站，以及各家 **Coding Plan**（智谱 GLM Coding、Z.AI、
+Kimi Coding、MiniMax Coding 国际/国内、火山方舟 Agent/Coding Plan）：5 小时窗口、
+周配额与 MCP 月度额度一目了然。
 
 v0.5 起为**双面插件** + **内置供应商目录自动发现**：安装并重启 `dsh web` 后，
 凡是 key 能解析的供应商都会自动出现在面板上——**零配置**。
@@ -244,6 +248,7 @@ VOLC_SECRET_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 - 显示 `No active Agent Plan or Coding Plan subscription` → 签名通过但该账号没有订阅 Agent/Coding Plan（按量付费账号就会这样，面板上可以在 ⚙ 设置里隐藏这一行）。
 
 > 安全建议：AK/SK 一旦泄露他人可以读你方舟账号的所有用量数据，贴到聊天/工单/截图前先打码；不再用时去 [密钥管理页](https://console.volcengine.com/iam/keymanage) 禁用并轮换。
+| ChatGPT 订阅（Plus/Pro） | `~/.codex/auth.json`（Codex 登录，无需 API Key） | `chatgpt.com/backend-api/wham/usage` | 周用量%（Pro 含 5h 窗口） |
 
 另内置 **`openai-billing`** 格式，适配 one-api / new-api 等聚合站：`endpoint` 配
 聚合站 base URL，宿主侧请求 `{base}/v1/dashboard/billing/subscription`
@@ -273,6 +278,36 @@ VOLC_SECRET_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 可按行覆盖：目录行自带 `currency`（SiliconFlow 国际行设为 `$`），
 `catalog:` 覆盖可设置，显式 `providers:` 条目接受 `currency` 字段
 （如 `"US$"`）。
+
+### ChatGPT 订阅（Plus/Pro）接入
+
+ChatGPT 订阅用量**不是 API 计费**，没有公开的余额/用量 API。本插件通过
+官方开源 Codex CLI 登录后写入的 `~/.codex/auth.json`，读取 ChatGPT OAuth
+令牌，调用 Codex 同款的内部用量端点，把 Plus/Pro 套餐的**周窗口（及 Pro
+的 5 小时窗口）已用百分比**显示在面板上。
+
+> ⚠️ **实验性（experimental）**：该端点（`chatgpt.com/backend-api/wham/usage`）
+> 是 Codex CLI 内部使用的未公开接口，响应字段可能随官方调整而变化。本插件
+> 只做只读查询，不会写入或修改你的 Codex 配置。
+
+**接入步骤：**
+
+1. 安装并登录 Codex CLI（任意方式：`npm i -g @openai/codex` 后运行 `codex`，
+   在浏览器完成 ChatGPT 登录）。登录会生成 `~/.codex/auth.json`；
+2. 无需在 `.credentials.yaml` 里配置任何 Key——插件自动探测 `auth.json`，
+   存在就显示 ChatGPT 行；
+3. 重启 `dsh web`。面板出现「ChatGPT」行，悬停可见 `plan: plus/pro` 与
+   `weekly: N%`（Pro 还会有 5h 窗口）。
+
+工作机制：access token 过期时，插件用 `auth.json` 里的 refresh token 向
+`auth.openai.com/oauth/token` 自动刷新；刷新后的令牌仅保存在插件进程内存中，
+**不会回写** `auth.json`（该文件归 Codex CLI 所有）。若 refresh 也失败
+（例如在别处重新登录导致令牌失效），面板会显示错误，重新运行一次 `codex`
+登录即可恢复。
+
+如果 `CODEX_HOME` 环境变量指向了自定义目录，插件会从
+`$CODEX_HOME/auth.json` 读取。
+
 ### 内置 format
 
 | format | 行类型 | 上游响应形态 |
@@ -290,6 +325,7 @@ VOLC_SECRET_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 | `zai-coding-quota` | 用量% | `{ code: 200, data: { limits: [{ type: TOKENS_LIMIT \| TIME_LIMIT, unit, number, percentage, currentValue, usage, nextResetTime }] } }` —— 语义映射（glm-plan-usage2，issue #2）：TOKENS_LIMIT `unit=3` → 5h 窗口、`unit=6` → 周、TIME_LIMIT → MCP 月度车道；未知 unit 回退按 `nextResetTime` 排序；各窗口百分比优先取 `percentage` 字段 |
 | `kimi-coding-usage` | 用量% | `{ usage: { limit, used, remaining, resetTime }, limits: [{ window: { duration, timeUnit }, detail: { limit, used, remaining, resetTime } }] }` —— 5h = `duration=300` 的窗口、周 = `duration=10080`（缺失时回退顶层 usage）；used = limit − remaining |
 | `volcengine-usage` | 用量% | 不走 `adaptRow`：`fetchRow` 内部以 AK/SK HMAC-SHA256 签名调用火山引擎 OpenAPI `GetAFPUsage` → `GetCodingPlanUsage`（回落），解析 `Result.AFPFiveHour/AFPWeekly/AFPMonthly`（Agent Plan，AFPDaily 跳过）或 `Result.QuotaUsage[].Level ∈ {session,weekly,monthly}`（Coding Plan，仅百分比） |
+| `chatgpt-subscription` | 用量% | `{ plan_type, rate_limit: { primary_window: { used_percent, reset_at }, secondary_window? } }` —— 经 `~/.codex/auth.json` 的 OAuth 令牌读取 Codex 内部用量端点；primary 映射为周窗口，secondary（Pro）映射为 5h 窗口。实验性接口 |
 
 ### 代理（部分供应商无法直连时）
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -87,7 +87,23 @@ window.__ModuleLoader__.load({
                 warnPercentPH: "预警 %（默认 {n}）",
                 warnBalancePH: "预警 {cur}（默认 {n}）",
                 localOnly: "设置仅保存在本浏览器",
-                resetDefaults: "恢复默认"
+                resetDefaults: "恢复默认",
+                chatgptAccount: "ChatGPT 账号",
+                chatgptLogin: "登录 ChatGPT",
+                chatgptLogout: "退出登录",
+                chatgptLoggedIn: "已登录（{source}）",
+                chatgptSourceDsh: "插件内登录",
+                chatgptSourceCodex: "Codex CLI",
+                chatgptPlan: "套餐：{plan}",
+                chatgptLoginHint: "未登录。点下方按钮，在浏览器用 ChatGPT 账号授权即可，无需安装 Codex CLI。",
+                chatgptLoginStep1: "1. 打开此链接并登录：",
+                chatgptLoginStep2: "2. 输入一次性验证码（15 分钟内有效）：",
+                chatgptWaiting: "等待浏览器授权中…",
+                chatgptLoginFailed: "登录失败：{msg}",
+                chatgptCopy: "复制",
+                chatgptCopied: "已复制",
+                chatgptOpenLink: "打开链接",
+                chatgptCancel: "取消"
             },
             en: {
                 title: "Model quota",
@@ -135,7 +151,23 @@ window.__ModuleLoader__.load({
                 warnPercentPH: "Warn % (default {n})",
                 warnBalancePH: "Warn {cur} (default {n})",
                 localOnly: "Stored in this browser only",
-                resetDefaults: "Reset defaults"
+                resetDefaults: "Reset defaults",
+                chatgptAccount: "ChatGPT account",
+                chatgptLogin: "Log in to ChatGPT",
+                chatgptLogout: "Log out",
+                chatgptLoggedIn: "Signed in ({source})",
+                chatgptSourceDsh: "in-plugin login",
+                chatgptSourceCodex: "Codex CLI",
+                chatgptPlan: "Plan: {plan}",
+                chatgptLoginHint: "Not signed in. Click below and authorize with your ChatGPT account in the browser — no Codex CLI install required.",
+                chatgptLoginStep1: "1. Open this link and sign in:",
+                chatgptLoginStep2: "2. Enter this one-time code (valid for 15 minutes):",
+                chatgptWaiting: "Waiting for browser authorization…",
+                chatgptLoginFailed: "Login failed: {msg}",
+                chatgptCopy: "Copy",
+                chatgptCopied: "Copied",
+                chatgptOpenLink: "Open link",
+                chatgptCancel: "Cancel"
             }
         };
         // Overlay lift (issue #1): shell.overlay renders inside AppFrame's
@@ -201,7 +233,11 @@ window.__ModuleLoader__.load({
             '#dsh-quota-card .dsh-setting-hint{color:var(--dsw-alias-label-tertiary,#818590);font-size:11px;line-height:16px}',
             '#dsh-quota-card .dsh-setting-reset{padding:3px 10px;border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.14));border-radius:8px;background:transparent;color:var(--dsw-alias-label-secondary,#61666b);font:inherit;font-size:12px;line-height:18px;cursor:pointer;transition:color 120ms ease,background-color 120ms ease}',
             '#dsh-quota-card .dsh-setting-proxy{width:150px}',
-            '#dsh-quota-card .dsh-setting-reset:hover{color:var(--dsw-alias-label-primary,#1b1b1c);background:var(--dsw-alias-interactive-bg-hover,rgba(0,0,0,.05))}'
+            '#dsh-quota-card .dsh-setting-reset:hover{color:var(--dsw-alias-label-primary,#1b1b1c);background:var(--dsw-alias-interactive-bg-hover,rgba(0,0,0,.05))}',
+            '#dsh-quota-card .dsh-chatgpt-row{align-self:stretch}',
+            '#dsh-quota-card .dsh-chatgpt-url a{color:var(--dsw-alias-brand,#3b82f6);font-size:11px;word-break:break-all}',
+            '#dsh-quota-card .dsh-chatgpt-code-row{display:flex;align-items:center;gap:8px}',
+            '#dsh-quota-card .dsh-chatgpt-code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:16px;font-weight:600;letter-spacing:2px;padding:4px 10px;border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.14));border-radius:8px;background:var(--dsw-alias-bg-raised,rgba(0,0,0,.03))}'
         ].join("\n");
         var CAPSULE_CHOICES = [
             { value: "auto" },
@@ -458,12 +494,122 @@ window.__ModuleLoader__.load({
             children.push(React.createElement("div", { key: "body", className: "dsh-provider-body" }, body));
             return React.createElement("div", { className: "dsh-provider state-" + view.status, title: view.title }, React.createElement("div", { className: "dsh-provider-main" }, children));
         }
+        /**
+         * ChatGPT account section. Self-contained: it queries the host's
+         * chatgpt-auth-* RPC endpoints and renders either a login button
+         * (which kicks off the device-code flow and shows the one-time code +
+         * verification URL) or a signed-in state with a log-out button.
+         * Secrets never reach this component — only status and codes.
+         */
+        function ChatGPTAccount(props) {
+            var t = props.t;
+            var call = props.call;
+            var statusState = React.useState(null);
+            var status = statusState[0], setStatus = statusState[1];
+            var busyState = React.useState(false);
+            var busy = busyState[0], setBusy = busyState[1];
+            var errorState = React.useState(null);
+            var errorMsg = errorState[0], setError = errorState[1];
+            var copiedState = React.useState(false);
+            var copied = copiedState[0], setCopied = copiedState[1];
+            var pollRef = React.useRef(null);
+            function sourceLabel(src) {
+                return src === "codex" ? t("chatgptSourceCodex") : t("chatgptSourceDsh");
+            }
+            function refresh() {
+                return call("chatgpt-auth-status", null).then(function (r) {
+                    if (r && r.ok)
+                        setStatus(r.value);
+                }).catch(function () { });
+            }
+            React.useEffect(function () {
+                refresh();
+                // While a login is in-flight, poll for completion; the host
+                // flips `login.active` to false when it obtains tokens.
+                var timer = setInterval(function () {
+                    call("chatgpt-auth-status", null).then(function (r) {
+                        if (r && r.ok) {
+                            setStatus(r.value);
+                            if (!r.value.login || !r.value.login.active) {
+                                setBusy(false);
+                            }
+                        }
+                    }).catch(function () { });
+                }, 2500);
+                pollRef.current = timer;
+                return function () { clearInterval(timer); };
+            }, []);
+            function startLogin() {
+                setError(null);
+                setBusy(true);
+                call("chatgpt-login-start", null).then(function (r) {
+                    if (!r || !r.ok) {
+                        setBusy(false);
+                        setError((r && r.error && r.error.message) || "failed");
+                    }
+                    // The host returns { verificationUrl, userCode }; refresh
+                    // status so the in-flight code renders.
+                    return refresh();
+                }).catch(function (e) {
+                    setBusy(false);
+                    setError(String(e && e.message ? e.message : e));
+                });
+            }
+            function cancelLogin() {
+                call("chatgpt-login-cancel", null).then(function () { setBusy(false); return refresh(); });
+            }
+            function logout() {
+                call("chatgpt-logout", null).then(function () { return refresh(); });
+            }
+            function copyCode(code) {
+                try {
+                    navigator.clipboard.writeText(code).then(function () {
+                        setCopied(true);
+                        setTimeout(function () { setCopied(false); }, 1500);
+                    }).catch(function () { });
+                }
+                catch (e) { /* clipboard may be unavailable */ }
+            }
+            var login = status && status.login;
+            var inFlight = busy || (login && login.active);
+            var children = [];
+            if (status && status.loggedIn && !(login && login.active)) {
+                children.push(React.createElement("div", { key: "in", className: "dsh-setting-hint" }, t("chatgptLoggedIn", { source: sourceLabel(status.source) })
+                    + (status.plan_type ? " · " + t("chatgptPlan", { plan: status.plan_type }) : "")));
+                children.push(React.createElement("button", {
+                    key: "out", className: "dsh-setting-reset", type: "button", onClick: logout
+                }, t("chatgptLogout")));
+            }
+            else if (inFlight && login && login.userCode) {
+                children.push(React.createElement("div", { key: "s1", className: "dsh-setting-hint" }, t("chatgptLoginStep1")));
+                children.push(React.createElement("div", { key: "url", className: "dsh-chatgpt-url" }, React.createElement("a", { href: login.verificationUrl, target: "_blank", rel: "noreferrer" }, login.verificationUrl)));
+                children.push(React.createElement("div", { key: "s2", className: "dsh-setting-hint", style: { marginTop: "6px" } }, t("chatgptLoginStep2")));
+                children.push(React.createElement("div", { key: "code", className: "dsh-chatgpt-code-row" }, React.createElement("span", { className: "dsh-chatgpt-code" }, login.userCode), React.createElement("button", {
+                    className: "dsh-setting-reset", type: "button", onClick: function () { copyCode(login.userCode); }
+                }, copied ? t("chatgptCopied") : t("chatgptCopy"))));
+                children.push(React.createElement("div", { key: "wait", className: "dsh-setting-hint", style: { marginTop: "6px" } }, t("chatgptWaiting")));
+                children.push(React.createElement("button", {
+                    key: "cancel", className: "dsh-setting-reset", type: "button", style: { marginTop: "6px" }, onClick: cancelLogin
+                }, t("chatgptCancel")));
+            }
+            else {
+                children.push(React.createElement("div", { key: "hint", className: "dsh-setting-hint" }, t("chatgptLoginHint")));
+                if (errorMsg) {
+                    children.push(React.createElement("div", { key: "err", className: "dsh-setting-hint", style: { color: "#e5484d" } }, t("chatgptLoginFailed", { msg: errorMsg })));
+                }
+                children.push(React.createElement("button", {
+                    key: "in", className: "dsh-setting-reset", type: "button", disabled: busy, onClick: startLogin
+                }, t("chatgptLogin")));
+            }
+            return React.createElement("div", { className: "dsh-setting-section" }, React.createElement("div", { className: "dsh-setting-title" }, t("chatgptAccount")), React.createElement("div", { className: "dsh-setting-row dsh-chatgpt-row", style: { flexDirection: "column", alignItems: "stretch", gap: "6px" } }, children));
+        }
         function SettingsPanel(props) {
             var specs = props.specs;
             var settings = props.settings;
             var onChange = props.onChange;
             var onReset = props.onReset;
             var t = props.t;
+            var call = props.call;
             var toggle = function (id) {
                 var hidden = Object.assign({}, settings.hidden);
                 if (hidden[id])
@@ -542,7 +688,7 @@ window.__ModuleLoader__.load({
                     onChange: function (event) { setWarn(spec.id, event.target.value); }
                 }));
             });
-            return React.createElement("div", { className: "dsh-quota-settings" }, React.createElement("div", { className: "dsh-setting-section" }, React.createElement("div", { className: "dsh-setting-title" }, t("settingsProviders")), visibilityRows.length ? visibilityRows : React.createElement("div", { className: "dsh-setting-hint" }, t("settingsNoProviders"))), React.createElement("div", { className: "dsh-setting-section" }, React.createElement("div", { className: "dsh-setting-title" }, t("settingsInterval")), React.createElement("div", { className: "dsh-setting-row" }, React.createElement("span", { className: "dsh-setting-name" }, t("settingsAutoRefresh")), React.createElement("select", {
+            return React.createElement("div", { className: "dsh-quota-settings" }, React.createElement(ChatGPTAccount, { key: "chatgpt", t: t, call: call }), React.createElement("div", { className: "dsh-setting-section" }, React.createElement("div", { className: "dsh-setting-title" }, t("settingsProviders")), visibilityRows.length ? visibilityRows : React.createElement("div", { className: "dsh-setting-hint" }, t("settingsNoProviders"))), React.createElement("div", { className: "dsh-setting-section" }, React.createElement("div", { className: "dsh-setting-title" }, t("settingsInterval")), React.createElement("div", { className: "dsh-setting-row" }, React.createElement("span", { className: "dsh-setting-name" }, t("settingsAutoRefresh")), React.createElement("select", {
                 className: "dsh-setting-select",
                 value: refreshValue,
                 onChange: function (event) { setRefresh(event.target.value); }
@@ -692,6 +838,9 @@ window.__ModuleLoader__.load({
                     globalThis.addEventListener("resize", reclamp);
                     return function () { globalThis.removeEventListener("resize", reclamp); };
                 }, [panelPos ? panelPos.x + ":" + panelPos.y : ""]);
+                var call = function (endpoint, payload) {
+                    return ctx.connection.rpc.call(CHANNEL, endpoint, payload);
+                };
                 var loadSpecs = function () {
                     return ctx.connection.rpc.call(CHANNEL, "specs", null).then(function (result) {
                         if (result && result.ok === true && result.value && Array.isArray(result.value.rows)) {
@@ -808,6 +957,7 @@ window.__ModuleLoader__.load({
                     bodyChildren.push(React.createElement(SettingsPanel, {
                         key: "settings",
                         t: t,
+                        call: call,
                         specs: specs,
                         settings: settings,
                         onChange: updateSettings,

--- a/lib/index.js
+++ b/lib/index.js
@@ -189,20 +189,35 @@ function volcengineSignedHeaders(ak, sk, region, action, now) {
 //   Authorization: Bearer <ChatGPT OAuth access_token>
 //   ChatGPT-Account-Id: <account_id>
 //
-// Tokens live in `~/.codex/auth.json` (written by `codex login`). The
-// access token is short-lived; we refresh it via the standard OAuth
-// token endpoint using the refresh_token from the same file. The
-// refreshed tokens are kept in an in-memory cache only — we do NOT
-// write back to auth.json, because that file is owned by the Codex CLI
-// (matching the ownership boundary CodexBar documents).
+// Two login methods are supported (resolveChatGPTToken tries them in order):
+//
+//   1. DSH-managed device-code login (no Codex CLI needed): the plugin
+//      runs the same OAuth 2.0 device-authorization flow Codex uses and
+//      persists tokens to $DSH_HOME/dsh-quota-panel/chatgpt-auth.json.
+//      The settings panel has a "Log in to ChatGPT" button that shows a
+//      one-time code + verification URL; the host polls and exchanges
+//      the authorization code (with PKCE) for tokens.
+//
+//   2. Codex CLI auth.json fallback: if the user has already logged in
+//      via `codex login`, tokens are read from ~/.codex/auth.json (or
+//      $CODEX_HOME/auth.json). This path never writes back to the file
+//      (Codex CLI owns it); refreshed tokens stay in process memory.
+//
+// Either way, the access token is refreshed host-side via the standard
+// OAuth token endpoint using the refresh_token; tokens never reach the
+// browser (rowSpec only forwards display fields).
 //
 // This adapter is explicitly experimental: the endpoint/shape are not
 // a public contract and may drift. Field names are verified against
 // live responses (2026-08) and the openai/codex client.
 const CHATGPT_USAGE_URL = 'https://chatgpt.com/backend-api/wham/usage';
 const CHATGPT_TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const CHATGPT_USERCODE_URL = 'https://auth.openai.com/api/accounts/deviceauth/usercode';
+const CHATGPT_DEVICETOKEN_URL = 'https://auth.openai.com/api/accounts/deviceauth/token';
+const CHATGPT_DEVICE_REDIRECT_URI = 'https://auth.openai.com/deviceauth/callback';
+const CHATGPT_DEVICE_VERIFY_URL = 'https://auth.openai.com/codex/device';
 const CHATGPT_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
-/** Directory containing auth.json; honors CODEX_HOME like the Codex CLI. */
+/** Directory containing the Codex auth.json; honors CODEX_HOME like the Codex CLI. */
 function chatgptCodexHome() {
     const override = process.env.CODEX_HOME;
     return override && override.length > 0 ? override : path.join(os.homedir(), '.codex');
@@ -211,8 +226,33 @@ function chatgptCodexHome() {
 function chatgptAuthJsonPath() {
     return path.join(chatgptCodexHome(), 'auth.json');
 }
-/** Returns true when the local Codex auth file exists (row auto-discovery probe). */
+/**
+ * Directory for the DSH-managed ChatGPT token store. Honors DSH_HOME
+ * (set by the harness), falling back to ~/.dsh. The file mode is
+ * restricted to the current user where the platform supports it.
+ */
+function chatgptDshStoreDir() {
+    const home = process.env.DSH_HOME;
+    return home && home.length > 0 ? home : path.join(os.homedir(), '.dsh');
+}
+function chatgptDshStorePath() {
+    return path.join(chatgptDshStoreDir(), 'dsh-quota-panel', 'chatgpt-auth.json');
+}
+/** Returns true when the Codex auth.json exists (distinct from DSH store). */
+async function codexAuthFileExists() {
+    try {
+        await fsp.access(chatgptAuthJsonPath());
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+/** Returns true when either a DSH-managed token or the Codex auth file exists (row auto-discovery probe). */
 async function chatgptAuthExists() {
+    const dsh = await readChatGPTDshStore();
+    if (dsh)
+        return true;
     try {
         await fsp.access(chatgptAuthJsonPath());
         return true;
@@ -255,6 +295,68 @@ async function readChatGPTAuthFile() {
         account_id: typeof tokens.account_id === 'string' ? tokens.account_id : undefined,
         expires_at_ms
     };
+}
+/**
+ * Read the DSH-managed ChatGPT token store (written by the in-plugin
+ * device-code login). Shape: { source:'dsh', account_id?, plan_type?,
+ * tokens:{access_token,refresh_token,id_token,expires_at_ms} }.
+ * Returns null (not throws) when absent/unreadable so the caller can
+ * fall through to the Codex auth.json source.
+ */
+async function readChatGPTDshStore() {
+    const file = chatgptDshStorePath();
+    let raw;
+    try {
+        raw = await fsp.readFile(file, 'utf8');
+    }
+    catch {
+        return null;
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(raw);
+    }
+    catch {
+        return null;
+    }
+    const t = parsed?.tokens;
+    if (!t || typeof t.access_token !== 'string' || t.access_token.length === 0)
+        return null;
+    return {
+        source: 'dsh',
+        access_token: t.access_token,
+        refresh_token: typeof t.refresh_token === 'string' ? t.refresh_token : undefined,
+        id_token: typeof t.id_token === 'string' ? t.id_token : undefined,
+        account_id: typeof parsed.account_id === 'string' ? parsed.account_id : undefined,
+        plan_type: typeof parsed.plan_type === 'string' ? parsed.plan_type : undefined,
+        expires_at_ms: typeof t.expires_at_ms === 'number' ? t.expires_at_ms : undefined
+    };
+}
+/** Atomically persist a token bundle to the DSH-managed store (0600 perms). */
+async function writeChatGPTDshStore(bundle) {
+    const file = chatgptDshStorePath();
+    await fsp.mkdir(path.dirname(file), { recursive: true });
+    const payload = JSON.stringify({
+        source: 'dsh',
+        account_id: bundle.account_id,
+        plan_type: bundle.plan_type,
+        tokens: {
+            access_token: bundle.access_token,
+            refresh_token: bundle.refresh_token,
+            id_token: bundle.id_token,
+            expires_at_ms: bundle.expires_at_ms
+        }
+    }, null, 2);
+    await fsp.writeFile(file, payload, { encoding: 'utf8', mode: 0o600 });
+}
+async function deleteChatGPTDshStore() {
+    try {
+        await fsp.unlink(chatgptDshStorePath());
+    }
+    catch {
+        // already absent
+    }
+    chatgptTokenCache = null;
 }
 /**
  * Call one Volcengine Ark OpenAPI action (POST with empty body, signed).
@@ -322,11 +424,176 @@ async function refreshChatGPTToken(refreshToken, timeoutMs) {
         expires_at_ms: Number.isFinite(expiresIn) && expiresIn > 0 ? Date.now() + expiresIn * 1000 : undefined
     };
 }
+/** PKCE verifier (high-entropy random string) and S256 challenge. */
+function chatgptPkce() {
+    const verifier = crypto.randomBytes(48).toString('base64url');
+    const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+    return { verifier, challenge };
+}
 /**
- * Resolve a usable access token: cache hit while fresh, else reload from
- * auth.json (which Codex may have refreshed in the meantime), else refresh
- * via the OAuth endpoint using the stored refresh_token. Refreshed tokens
- * are cached in memory only.
+ * In-flight device-code login. The host drives the OAuth device-authorization
+ * flow: it requests a one-time user code, the UI shows it with the
+ * verification URL, and the host polls until the user authorizes (or it
+ * times out / is cancelled). `abort` is set when the user cancels so the
+ * polling loop terminates and the next start can replace it.
+ */
+let chatgptLogin = null;
+/** Step 1: request a one-time code from the device-authorization endpoint. */
+async function chatgptDeviceStart(timeoutMs) {
+    const res = await fetch(CHATGPT_USERCODE_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+        body: JSON.stringify({ client_id: CHATGPT_CLIENT_ID }),
+        signal: AbortSignal.timeout(timeoutMs)
+    });
+    const json = await res.json().catch(() => null);
+    if (!res.ok || json === null) {
+        throw new Error(`ChatGPT device code request failed: ${json?.error_description || json?.error || `HTTP ${res.status}`}`);
+    }
+    const userCode = json.user_code ?? json.usercode;
+    const deviceAuthId = json.device_auth_id;
+    if (typeof userCode !== 'string' || !userCode || typeof deviceAuthId !== 'string') {
+        throw new Error('ChatGPT device code response missing user_code / device_auth_id');
+    }
+    const intervalSec = Number(json.interval);
+    const intervalMs = Number.isFinite(intervalSec) && intervalSec > 0 ? intervalSec * 1000 : 5000;
+    // The one-time code expires in 15 minutes (per Codex's device flow).
+    const expiresAt = Date.now() + 15 * 60 * 1000;
+    chatgptLogin = {
+        startedAt: Date.now(),
+        verificationUrl: CHATGPT_DEVICE_VERIFY_URL,
+        userCode,
+        intervalMs,
+        expiresAt,
+        abort: false
+    };
+    void chatgptDevicePoll(deviceAuthId, userCode, intervalMs);
+    return { verificationUrl: CHATGPT_DEVICE_VERIFY_URL, userCode, intervalMs, expiresAt };
+}
+/**
+ * Step 2: poll the device token endpoint until the user authorizes. On
+ * success the response carries an authorization_code plus PKCE codes; we
+ * then exchange the code for tokens and persist them to the DSH store.
+ * Errors (pending/denied/expired) are swallowed here and surfaced to the
+ * UI via chatgptLoginStatus().
+ */
+async function chatgptDevicePoll(deviceAuthId, userCode, initialIntervalMs) {
+    const deadline = Date.now() + 15 * 60 * 1000;
+    let intervalMs = initialIntervalMs;
+    let lastError;
+    while (Date.now() < deadline) {
+        if (chatgptLogin?.abort || chatgptLogin?.userCode !== userCode)
+            return;
+        await new Promise((r) => setTimeout(r, intervalMs));
+        if (chatgptLogin?.abort || chatgptLogin?.userCode !== userCode)
+            return;
+        try {
+            const res = await fetch(CHATGPT_DEVICETOKEN_URL, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+                body: JSON.stringify({ device_auth_id: deviceAuthId, user_code: userCode }),
+                signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS)
+            });
+            const json = await res.json().catch(() => null);
+            if (!json)
+                continue;
+            if (json.authorization_code) {
+                const verifier = typeof json.code_verifier === 'string' && json.code_verifier
+                    ? json.code_verifier
+                    : chatgptPkce().verifier;
+                const tokens = await chatgptExchangeCode(String(json.authorization_code), verifier);
+                await writeChatGPTDshStore(tokens);
+                chatgptTokenCache = { bundle: tokens };
+                chatgptLogin = null;
+                return;
+            }
+            // authorization_pending / slow_down / access_denied / expired_token
+            lastError = json.error_description || json.error || lastError;
+            if (json.error === 'access_denied' || json.error === 'expired_token')
+                break;
+            if (json.error === 'slow_down' && intervalMs < 15000) {
+                intervalMs = Math.min(15000, intervalMs + 5000);
+            }
+        }
+        catch (e) {
+            lastError = String(e?.message || e);
+        }
+    }
+    chatgptLogin = null;
+    throw new Error(lastError ? `ChatGPT login failed: ${lastError}` : 'ChatGPT login timed out');
+}
+/** Step 3: exchange an authorization_code (with PKCE) for a token bundle. */
+async function chatgptExchangeCode(code, codeVerifier, timeoutMs = UPSTREAM_TIMEOUT_MS) {
+    const body = new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: CHATGPT_DEVICE_REDIRECT_URI,
+        client_id: CHATGPT_CLIENT_ID,
+        code_verifier: codeVerifier
+    }).toString();
+    const res = await fetch(CHATGPT_TOKEN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+        signal: AbortSignal.timeout(timeoutMs)
+    });
+    const json = await res.json().catch(() => null);
+    if (!res.ok || json === null) {
+        throw new Error(`ChatGPT token exchange failed: ${json?.error_description || json?.error || `HTTP ${res.status}`}`);
+    }
+    if (typeof json.access_token !== 'string' || json.access_token.length === 0) {
+        throw new Error('ChatGPT token exchange response missing access_token');
+    }
+    const expiresIn = Number(json.expires_in);
+    let account_id;
+    let plan_type;
+    if (typeof json.id_token === 'string') {
+        const claims = chatgptDecodeIdToken(json.id_token);
+        account_id = claims.account_id;
+        plan_type = claims.plan_type;
+    }
+    return {
+        access_token: json.access_token,
+        refresh_token: typeof json.refresh_token === 'string' ? json.refresh_token : undefined,
+        id_token: typeof json.id_token === 'string' ? json.id_token : undefined,
+        account_id,
+        plan_type,
+        expires_at_ms: Number.isFinite(expiresIn) && expiresIn > 0 ? Date.now() + expiresIn * 1000 : undefined
+    };
+}
+/** Decode (without verifying) the id_token JWT payload for account/plan hints. */
+function chatgptDecodeIdToken(idToken) {
+    try {
+        const part = idToken.split('.')[1];
+        if (!part)
+            return {};
+        const json = JSON.parse(Buffer.from(part.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'));
+        const ns = json?.['https://api.openai.com/auth'];
+        return {
+            account_id: typeof json?.account_id === 'string' ? json.account_id : (typeof ns?.user_id === 'string' ? ns.user_id : undefined),
+            plan_type: typeof json?.plan_type === 'string' ? json.plan_type : (typeof ns?.plan_type === 'string' ? ns.plan_type : undefined)
+        };
+    }
+    catch {
+        return {};
+    }
+}
+/** Snapshot of the current in-flight login for the settings UI to render. */
+function chatgptLoginStatus() {
+    if (!chatgptLogin || chatgptLogin.abort)
+        return { active: false };
+    return {
+        active: true,
+        verificationUrl: chatgptLogin.verificationUrl,
+        userCode: chatgptLogin.userCode,
+        expiresAt: chatgptLogin.expiresAt
+    };
+}
+/**
+ * Resolve a usable access token. Order:
+ *   1. in-memory cache while fresh
+ *   2. DSH-managed store (device-code login) — refreshed and written back
+ *   3. ~/.codex/auth.json (Codex CLI login) — refreshed in memory only
  */
 async function resolveChatGPTToken(timeoutMs) {
     const now = Date.now();
@@ -334,14 +601,30 @@ async function resolveChatGPTToken(timeoutMs) {
     if (cached && cached.access_token && (!cached.expires_at_ms || cached.expires_at_ms - now > 30_000)) {
         return { accessToken: cached.access_token, accountId: cached.account_id };
     }
+    // Source 1: DSH-managed device login (preferred).
+    const dsh = await readChatGPTDshStore();
+    if (dsh && dsh.access_token) {
+        if (!dsh.expires_at_ms || dsh.expires_at_ms - now > 30_000) {
+            chatgptTokenCache = { bundle: dsh };
+            return { accessToken: dsh.access_token, accountId: dsh.account_id };
+        }
+        if (dsh.refresh_token) {
+            const refreshed = await refreshChatGPTToken(dsh.refresh_token, timeoutMs);
+            if (!refreshed.account_id)
+                refreshed.account_id = dsh.account_id;
+            await writeChatGPTDshStore(refreshed).catch(() => { });
+            chatgptTokenCache = { bundle: refreshed };
+            return { accessToken: refreshed.access_token, accountId: refreshed.account_id };
+        }
+    }
+    // Source 2: Codex CLI auth.json fallback.
     const fromDisk = await readChatGPTAuthFile();
     if (!fromDisk.expires_at_ms || fromDisk.expires_at_ms - now > 30_000) {
         chatgptTokenCache = { bundle: fromDisk };
         return { accessToken: fromDisk.access_token, accountId: fromDisk.account_id };
     }
-    // Disk token is expired/near-expiry — refresh.
     if (!fromDisk.refresh_token) {
-        throw new Error('ChatGPT: access token expired and auth.json has no refresh_token — run "codex login" again');
+        throw new Error('ChatGPT: access token expired and no refresh_token — log in again');
     }
     const refreshed = await refreshChatGPTToken(fromDisk.refresh_token, timeoutMs);
     if (!refreshed.account_id)
@@ -1363,6 +1646,40 @@ export function apply(ctx, config = {}) {
     const providers = validateProviders({ providers: Array.isArray(raw.providers) ? raw.providers : [], proxies });
     ctx.connection.rpc.handle(RPC_CHANNEL, async (endpoint, payload, _signal) => {
         try {
+            // ── ChatGPT subscription auth (device-code login) ──────
+            // These endpoints drive the in-plugin device-authorization
+            // flow so users without Codex CLI can still log in. No
+            // secrets leave the host.
+            if (endpoint === 'chatgpt-auth-status') {
+                const dsh = await readChatGPTDshStore();
+                return {
+                    ok: true,
+                    value: {
+                        loggedIn: !!(dsh?.access_token) || await chatgptAuthExists(),
+                        source: dsh ? 'dsh' : (await codexAuthFileExists() ? 'codex' : null),
+                        account_id: dsh?.account_id,
+                        plan_type: dsh?.plan_type,
+                        login: chatgptLoginStatus()
+                    }
+                };
+            }
+            if (endpoint === 'chatgpt-login-start') {
+                // Cancel any in-flight login, then start a fresh one.
+                if (chatgptLogin)
+                    chatgptLogin.abort = true;
+                const info = await chatgptDeviceStart(UPSTREAM_TIMEOUT_MS);
+                return { ok: true, value: info };
+            }
+            if (endpoint === 'chatgpt-login-cancel') {
+                if (chatgptLogin)
+                    chatgptLogin.abort = true;
+                chatgptLogin = null;
+                return { ok: true, value: { cancelled: true } };
+            }
+            if (endpoint === 'chatgpt-logout') {
+                await deleteChatGPTDshStore();
+                return { ok: true, value: { loggedOut: true } };
+            }
             const rows = await resolveRows(ctx, {
                 auto: raw.auto !== false,
                 hide: Array.isArray(raw.hide) ? raw.hide : [],

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,9 @@
  * repo's real path, which cannot walk up to dsh's bundled packages.
  */
 import crypto from 'node:crypto';
+import { promises as fsp } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import http from 'node:http';
 import https from 'node:https';
 import net from 'node:net';
@@ -176,6 +179,83 @@ function volcengineSignedHeaders(ak, sk, region, action, now) {
         'Authorization': `HMAC-SHA256 Credential=${ak}/${credentialScope}, SignedHeaders=${VOLCENGINE_SIGNED_HEADERS}, Signature=${signature}`
     };
 }
+// ── ChatGPT subscription (Codex OAuth) usage ────────────────
+//
+// ChatGPT Plus/Pro/Business plans have no public usage API, but the
+// official open-source Codex CLI authenticates against an EXPERIMENTAL
+// internal endpoint that returns the current plan's rate-limit windows:
+//
+//   GET https://chatgpt.com/backend-api/wham/usage
+//   Authorization: Bearer <ChatGPT OAuth access_token>
+//   ChatGPT-Account-Id: <account_id>
+//
+// Tokens live in `~/.codex/auth.json` (written by `codex login`). The
+// access token is short-lived; we refresh it via the standard OAuth
+// token endpoint using the refresh_token from the same file. The
+// refreshed tokens are kept in an in-memory cache only — we do NOT
+// write back to auth.json, because that file is owned by the Codex CLI
+// (matching the ownership boundary CodexBar documents).
+//
+// This adapter is explicitly experimental: the endpoint/shape are not
+// a public contract and may drift. Field names are verified against
+// live responses (2026-08) and the openai/codex client.
+const CHATGPT_USAGE_URL = 'https://chatgpt.com/backend-api/wham/usage';
+const CHATGPT_TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const CHATGPT_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+/** Directory containing auth.json; honors CODEX_HOME like the Codex CLI. */
+function chatgptCodexHome() {
+    const override = process.env.CODEX_HOME;
+    return override && override.length > 0 ? override : path.join(os.homedir(), '.codex');
+}
+/** Absolute path to the Codex auth.json. Resolved lazily so tests can steer via CODEX_HOME. */
+function chatgptAuthJsonPath() {
+    return path.join(chatgptCodexHome(), 'auth.json');
+}
+/** Returns true when the local Codex auth file exists (row auto-discovery probe). */
+async function chatgptAuthExists() {
+    try {
+        await fsp.access(chatgptAuthJsonPath());
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+/** In-memory token cache; refreshed on expiry or on auth failure. */
+let chatgptTokenCache = null;
+async function readChatGPTAuthFile() {
+    const authJson = chatgptAuthJsonPath();
+    let raw;
+    try {
+        raw = await fsp.readFile(authJson, 'utf8');
+    }
+    catch (err) {
+        throw new Error(`ChatGPT: cannot read ${authJson} (run "codex login" first): ${err.message}`);
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(raw);
+    }
+    catch {
+        throw new Error(`ChatGPT: ${authJson} is not valid JSON`);
+    }
+    const tokens = parsed?.tokens;
+    if (!tokens || typeof tokens !== 'object' || typeof tokens.access_token !== 'string' || tokens.access_token.length === 0) {
+        throw new Error(`ChatGPT: ${authJson} has no tokens.access_token (run "codex login")`);
+    }
+    let expires_at_ms;
+    if (typeof tokens.expires_at === 'number' && Number.isFinite(tokens.expires_at) && tokens.expires_at > 0) {
+        // Codex writes epoch seconds; tolerate ms.
+        expires_at_ms = tokens.expires_at > 1e12 ? tokens.expires_at : tokens.expires_at * 1000;
+    }
+    return {
+        access_token: tokens.access_token,
+        refresh_token: typeof tokens.refresh_token === 'string' ? tokens.refresh_token : undefined,
+        id_token: typeof tokens.id_token === 'string' ? tokens.id_token : undefined,
+        account_id: typeof tokens.account_id === 'string' ? tokens.account_id : undefined,
+        expires_at_ms
+    };
+}
 /**
  * Call one Volcengine Ark OpenAPI action (POST with empty body, signed).
  * Volcengine returns business errors as 200 + ResponseMetadata.Error, so
@@ -211,6 +291,133 @@ async function volcengineCall(action, region, ak, sk, timeoutMs) {
     return body;
 }
 /**
+ * Exchange a refresh_token for a fresh access token at the OpenAI OAuth
+ * endpoint. Form-urlencoded as required by the OAuth2 token endpoint.
+ */
+async function refreshChatGPTToken(refreshToken, timeoutMs) {
+    const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: CHATGPT_CLIENT_ID
+    }).toString();
+    const res = await fetch(CHATGPT_TOKEN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+        signal: AbortSignal.timeout(timeoutMs)
+    });
+    const json = await res.json().catch(() => null);
+    if (!res.ok || json === null) {
+        const msg = json?.error_description || json?.error || `HTTP ${res.status}`;
+        throw new Error(`ChatGPT token refresh failed: ${msg}`);
+    }
+    if (typeof json.access_token !== 'string' || json.access_token.length === 0) {
+        throw new Error('ChatGPT token refresh response missing access_token');
+    }
+    const expiresIn = Number(json.expires_in);
+    return {
+        access_token: json.access_token,
+        refresh_token: typeof json.refresh_token === 'string' ? json.refresh_token : refreshToken,
+        id_token: typeof json.id_token === 'string' ? json.id_token : undefined,
+        expires_at_ms: Number.isFinite(expiresIn) && expiresIn > 0 ? Date.now() + expiresIn * 1000 : undefined
+    };
+}
+/**
+ * Resolve a usable access token: cache hit while fresh, else reload from
+ * auth.json (which Codex may have refreshed in the meantime), else refresh
+ * via the OAuth endpoint using the stored refresh_token. Refreshed tokens
+ * are cached in memory only.
+ */
+async function resolveChatGPTToken(timeoutMs) {
+    const now = Date.now();
+    const cached = chatgptTokenCache?.bundle;
+    if (cached && cached.access_token && (!cached.expires_at_ms || cached.expires_at_ms - now > 30_000)) {
+        return { accessToken: cached.access_token, accountId: cached.account_id };
+    }
+    const fromDisk = await readChatGPTAuthFile();
+    if (!fromDisk.expires_at_ms || fromDisk.expires_at_ms - now > 30_000) {
+        chatgptTokenCache = { bundle: fromDisk };
+        return { accessToken: fromDisk.access_token, accountId: fromDisk.account_id };
+    }
+    // Disk token is expired/near-expiry — refresh.
+    if (!fromDisk.refresh_token) {
+        throw new Error('ChatGPT: access token expired and auth.json has no refresh_token — run "codex login" again');
+    }
+    const refreshed = await refreshChatGPTToken(fromDisk.refresh_token, timeoutMs);
+    if (!refreshed.account_id)
+        refreshed.account_id = fromDisk.account_id;
+    chatgptTokenCache = { bundle: refreshed };
+    return { accessToken: refreshed.access_token, accountId: refreshed.account_id };
+}
+/**
+ * Call the experimental ChatGPT usage endpoint. On a 401 the caller may
+ * retry once after forcing a token refresh.
+ */
+async function fetchChatGPTUsage(accessToken, accountId, timeoutMs) {
+    const headers = {
+        'Authorization': `Bearer ${accessToken}`,
+        'Accept': 'application/json'
+    };
+    if (accountId)
+        headers['ChatGPT-Account-Id'] = accountId;
+    const res = await fetch(CHATGPT_USAGE_URL, { headers, signal: AbortSignal.timeout(timeoutMs) });
+    const body = await res.json().catch(() => null);
+    if (res.status === 401) {
+        const err = new Error('ChatGPT: access token rejected (401)');
+        err.code = 'chatgpt-auth';
+        throw err;
+    }
+    if (body === null)
+        throw new Error(`ChatGPT: HTTP ${res.status} non-JSON response`);
+    if (!res.ok)
+        throw new Error(`ChatGPT: HTTP ${res.status}: ${body?.detail || body?.error || 'unknown error'}`);
+    return body;
+}
+/**
+ * Normalize a wham/usage response into the plugin's usage view.
+ * primary_window is the weekly allowance; secondary_window (Pro plans)
+ * is the shorter 5h window. We surface primary as `weekly` and, when
+ * present, secondary as `rolling`, matching the coding-plan convention.
+ */
+function parseChatGPTUsage(body) {
+    const rl = body?.rate_limit;
+    if (!rl || typeof rl !== 'object')
+        return null;
+    const toIso = (epochSec) => {
+        const n = Number(epochSec);
+        if (!Number.isFinite(n) || n <= 0)
+            return undefined;
+        return new Date(n > 1e12 ? n : n * 1000).toISOString();
+    };
+    const mapWindow = (w) => {
+        if (!w || typeof w !== 'object')
+            return null;
+        const pct = Number(w.used_percent);
+        if (!Number.isFinite(pct))
+            return null;
+        return {
+            percent: Math.min(100, Math.max(0, Math.round(pct))),
+            resetsAt: toIso(w.reset_at)
+        };
+    };
+    const windows = {};
+    const primary = mapWindow(rl.primary_window);
+    if (primary)
+        windows.weekly = primary;
+    const secondary = mapWindow(rl.secondary_window);
+    if (secondary)
+        windows.rolling = secondary;
+    if (Object.keys(windows).length === 0)
+        return null;
+    const plan = typeof body?.plan_type === 'string' && body.plan_type ? body.plan_type : 'subscription';
+    const titleParts = [
+        `plan: ${plan}`,
+        windows.rolling ? `5h: ${windows.rolling.percent}%` : null,
+        windows.weekly ? `weekly: ${windows.weekly.percent}%` : null
+    ].filter(Boolean);
+    return { kind: 'usage', windows, title: titleParts.join('\n') };
+}
+/**
  * Normalized row views an adapter may produce. The browser half renders
  * these generically; upstream response schema details never leave the host.
  * @typedef {object} RowView
@@ -237,7 +444,8 @@ const FORMAT_META = {
     'opencode-usage': { kind: 'usage' },
     'zai-coding-quota': { kind: 'usage' },
     'kimi-coding-usage': { kind: 'usage' },
-    'volcengine-usage': { kind: 'usage' }
+    'volcengine-usage': { kind: 'usage' },
+    'chatgpt-subscription': { kind: 'usage' }
 };
 /**
  * Built-in provider catalog probed by auto discovery. `refs` lists the
@@ -263,10 +471,16 @@ const CATALOG = [
     // OpenAPI control plane. Unlike every other catalog row this one
     // authenticates with an AK/SK pair (signed, not Bearer) —
     // `secretRefs` is the second credential and fetchRow signs the request.
-    { id: 'volcengine', label: 'Volcengine Ark', refs: ['VOLC_ACCESS_KEY'], secretRefs: ['VOLC_SECRET_KEY'], endpoint: 'https://open.volcengineapi.com', format: 'volcengine-usage', windowLabels: { rolling: '5h', weekly: '周', monthly: '月' } }
+    { id: 'volcengine', label: 'Volcengine Ark', refs: ['VOLC_ACCESS_KEY'], secretRefs: ['VOLC_SECRET_KEY'], endpoint: 'https://open.volcengineapi.com', format: 'volcengine-usage', windowLabels: { rolling: '5h', weekly: '周', monthly: '月' } },
+    // ChatGPT subscription (Plus/Pro/Business via Codex OAuth). Unlike every
+    // other row this does NOT use ctx.credentials: tokens are read from
+    // ~/.codex/auth.json (written by `codex login`) and refreshed host-side.
+    // `localAuth: 'codex'` makes resolveRows skip credential probing and always
+    // surface the row (the row errors at fetch time if auth.json is missing).
+    { id: 'chatgpt', label: 'ChatGPT', localAuth: 'codex', endpoint: CHATGPT_USAGE_URL, format: 'chatgpt-subscription', windowLabels: { rolling: '5h', weekly: '周' } }
 ];
 /** Keys a `catalog` override may set on an auto-discovered row. */
-const CATALOG_OVERRIDE_KEYS = ['label', 'endpoint', 'format', 'proxy', 'refs', 'secretRefs', 'currency', 'balanceTiers', 'warnPercent', 'errorPercent', 'windowLabels'];
+const CATALOG_OVERRIDE_KEYS = ['label', 'endpoint', 'format', 'proxy', 'refs', 'secretRefs', 'currency', 'balanceTiers', 'warnPercent', 'errorPercent', 'windowLabels', 'localAuth'];
 /**
  * Format adapters: upstream JSON → RowView. Each returns a view or throws
  * with a message prefixed by the format id; callers capture per row.
@@ -515,6 +729,11 @@ const FORMATS = {
     // format is registered in FORMATS/FORMAT_META for config validation.
     'volcengine-usage': () => {
         throw new Error('volcengine-usage is handled inline by fetchRow');
+    },
+    // chatgpt-subscription is dispatched inline in fetchRow because it uses
+    // an OAuth token from ~/.codex/auth.json (with refresh), not ctx.credentials.
+    'chatgpt-subscription': () => {
+        throw new Error('chatgpt-subscription is handled inline by fetchRow');
     }
 };
 /**
@@ -533,17 +752,18 @@ export const Config = z.object({
         label: z.string().required(),
         credential: z.string().role('credential-ref').required(),
         secretCredential: z.string().role('credential-ref'),
+        region: z.string(),
+        localAuth: z.union([z.const('codex')]),
         endpoint: z.string().pattern(HTTP_URL_PATTERN).required(),
         format: z.union([
             z.const('deepseek-balance'), z.const('openrouter-credits'), z.const('siliconflow-balance'),
             z.const('moonshot-balance'), z.const('minimax-remains'), z.const('stepfun-accounts'),
             z.const('xai-credits'), z.const('openai-billing'), z.const('zhipu-quota'),
             z.const('opencode-usage'), z.const('zai-coding-quota'), z.const('kimi-coding-usage'),
-            z.const('volcengine-usage')
+            z.const('volcengine-usage'), z.const('chatgpt-subscription')
         ]).default('deepseek-balance'),
         proxy: z.string(),
         currency: z.string(),
-        region: z.string(),
         balanceTiers: z.object({
             critical: z.number().default(10),
             warn: z.number().default(20),
@@ -839,26 +1059,41 @@ async function resolveRows(ctx, raw) {
                 continue;
             const override = raw.catalog[entry.id] || {};
             const merged = { ...entry, ...override };
-            const hit = await firstResolvedRef(ctx, merged.refs);
-            if (!hit)
-                continue;
-            // Two-credential rows (e.g. Volcengine AK/SK): the row is only
-            // discoverable once BOTH refs resolve. The resolved ref NAME is
-            // stored (not the value); fetchRow re-resolves per cycle.
+            let credentialRef;
             let secretCredential;
-            if (Array.isArray(merged.secretRefs) && merged.secretRefs.length > 0) {
-                const secretHit = await firstResolvedRef(ctx, merged.secretRefs);
-                if (!secretHit)
+            if (merged.localAuth) {
+                // localAuth rows (ChatGPT via ~/.codex/auth.json) probe the
+                // local auth source each cycle; they join the panel only when
+                // that source exists. They surface their own fetch error if
+                // the file later disappears or is malformed.
+                if (merged.localAuth === 'codex' && !(await chatgptAuthExists()))
                     continue;
-                secretCredential = secretHit.ref;
+                credentialRef = undefined;
+            }
+            else {
+                // Bearer/key rows: the primary ref must resolve. Two-credential
+                // rows (e.g. Volcengine AK/SK) require BOTH refs; the resolved
+                // ref NAME is stored (not the value); fetchRow re-resolves per
+                // cycle.
+                const hit = await firstResolvedRef(ctx, merged.refs);
+                if (!hit)
+                    continue;
+                credentialRef = hit.ref;
+                if (Array.isArray(merged.secretRefs) && merged.secretRefs.length > 0) {
+                    const secretHit = await firstResolvedRef(ctx, merged.secretRefs);
+                    if (!secretHit)
+                        continue;
+                    secretCredential = secretHit.ref;
+                }
             }
             const at = `quota-panel: config.catalog.${entry.id}`;
             rows.push({
                 id: merged.id,
                 label: merged.label,
-                credential: hit.ref,
+                credential: credentialRef,
                 secretCredential,
                 region: merged.region,
+                localAuth: merged.localAuth,
                 endpoint: merged.endpoint,
                 format: merged.format,
                 proxy: merged.proxy,
@@ -994,6 +1229,40 @@ function adaptRow(format, body) {
  */
 async function fetchRow(ctx, provider, proxies, clientProxyUrl) {
     try {
+        // ── ChatGPT subscription (Codex OAuth) ──────────────────
+        // Reads tokens from ~/.codex/auth.json, refreshes host-side,
+        // and queries the experimental wham/usage endpoint. On a 401
+        // we force a single token refresh retry.
+        if (provider.format === 'chatgpt-subscription') {
+            try {
+                let { accessToken, accountId } = await resolveChatGPTToken(UPSTREAM_TIMEOUT_MS);
+                let body;
+                try {
+                    body = await fetchChatGPTUsage(accessToken, accountId, UPSTREAM_TIMEOUT_MS);
+                }
+                catch (e) {
+                    if (e?.code === 'chatgpt-auth') {
+                        // Drop the cached token and refresh once.
+                        chatgptTokenCache = null;
+                        const refreshed = await resolveChatGPTToken(UPSTREAM_TIMEOUT_MS);
+                        accessToken = refreshed.accessToken;
+                        accountId = refreshed.accountId;
+                        body = await fetchChatGPTUsage(accessToken, accountId, UPSTREAM_TIMEOUT_MS);
+                    }
+                    else {
+                        throw e;
+                    }
+                }
+                const view = parseChatGPTUsage(body);
+                if (!view) {
+                    return { id: provider.id, error: 'ChatGPT: no rate_limit data in usage response' };
+                }
+                return { id: provider.id, view };
+            }
+            catch (e) {
+                return { id: provider.id, error: String((e && e.message) || e) };
+            }
+        }
         const hit = await ctx.credentials.resolve(provider.credential);
         if (!hit || typeof hit.value !== 'string' || hit.value.length === 0) {
             return { id: provider.id, error: `${provider.credential} is not configured` };

--- a/scripts/test-page-script.mjs
+++ b/scripts/test-page-script.mjs
@@ -10,7 +10,7 @@
 // shell.overlay slot registration, and the settings-panel surface.
 import vm from 'node:vm';
 import http from 'node:http';
-import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -544,6 +544,54 @@ plugin.apply(noCtx, {});
 const noSpecs = await noRegs[0].h('specs', null, undefined);
 check('A: chatgpt hidden when auth.json does not exist', !noSpecs.value.rows.some((r) => r.id === 'chatgpt'));
 process.env.CODEX_HOME = prevCodexHome;
+
+// DSH-managed device-login token store: when $DSH_HOME/dsh-quota-panel/chatgpt-auth.json
+// exists but no Codex auth.json does, the row should still appear and the auth-status
+// RPC should report source='dsh'.
+{
+	const prevDsh = process.env.DSH_HOME;
+	const dshHome = mkdtempSync(join(tmpdir(), 'dsh-qp-dshhome-'));
+	process.env.DSH_HOME = dshHome;
+	const storeDir = join(dshHome, 'dsh-quota-panel');
+	mkdirSync(storeDir, { recursive: true });
+	const exp = Date.now() + 3600_000;
+	writeFileSync(join(storeDir, 'chatgpt-auth.json'), JSON.stringify({
+		source: 'dsh', account_id: 'acct-dsh-1', plan_type: 'pro',
+		tokens: { access_token: 'eyJ.dsh-access', refresh_token: 'rt-dsh', id_token: 'x', expires_at_ms: exp }
+	}));
+	const regs = [];
+	const ctx2 = { connection: { rpc: { handle: (ch, h) => { regs.push({ ch, h }); return async () => {}; } } }, credentials: { resolve: async () => undefined } };
+	plugin.apply(ctx2, {});
+	const h2 = regs[0].h;
+	const s2 = await h2('specs', null, undefined);
+	check('A: chatgpt discovered via DSH store without Codex auth.json', s2.value.rows.some((r) => r.id === 'chatgpt'));
+	const st = await h2('chatgpt-auth-status', null, undefined);
+	check('A: chatgpt-auth-status reports source=dsh + plan', st.ok && st.value.source === 'dsh' && st.value.loggedIn === true && st.value.plan_type === 'pro');
+	// logout removes the DSH store and flips status
+	await h2('chatgpt-logout', null, undefined);
+	const st2 = await h2('chatgpt-auth-status', null, undefined);
+	check('A: chatgpt-logout clears DSH store', st2.ok && st2.value.loggedIn === false && st2.value.source === null);
+	process.env.DSH_HOME = prevDsh;
+}
+// chatgpt-login-start: when there is no Codex auth and no DSH store, the host
+// should return a one-time code + verification URL (network permitting). We do
+// not hit the real network in CI; just assert the RPC surface exists and
+// cancelling leaves no in-flight state.
+{
+	const prevDsh = process.env.DSH_HOME;
+	const prevCodex = process.env.CODEX_HOME;
+	process.env.DSH_HOME = mkdtempSync(join(tmpdir(), 'dsh-qp-empty-dsh-'));
+	process.env.CODEX_HOME = mkdtempSync(join(tmpdir(), 'dsh-qp-empty-codex-'));
+	const regs = [];
+	const ctx3 = { connection: { rpc: { handle: (ch, h) => { regs.push({ ch, h }); return async () => {}; } } }, credentials: { resolve: async () => undefined } };
+	plugin.apply(ctx3, {});
+	const h3 = regs[0].h;
+	// cancel is safe even with nothing in flight
+	const c = await h3('chatgpt-login-cancel', null, undefined);
+	check('A: chatgpt-login-cancel is safe with no in-flight login', c.ok === true && c.value.cancelled === true);
+	process.env.DSH_HOME = prevDsh;
+	process.env.CODEX_HOME = prevCodex;
+}
 
 // ---------- A2d: search lane unknown / absent weekly (no fabricated 0%) ----------
 credentialMap = { ZAI_CODING_CN_API_KEY: 'sk-zai-cn', ZAI_API_KEY: 'sk-zai', KIMI_API_KEY: 'sk-kimi', MINIMAX_CN_API_KEY: 'sk-mmcn', ZHIPU_API_KEY: 'sk-zp' };

--- a/scripts/test-page-script.mjs
+++ b/scripts/test-page-script.mjs
@@ -10,9 +10,16 @@
 // shell.overlay slot registration, and the settings-panel surface.
 import vm from 'node:vm';
 import http from 'node:http';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+
+// Hermetic default: point CODEX_HOME at an empty temp dir so the ChatGPT
+// subscription row (which auto-discovers ~/.codex/auth.json) does not leak
+// the developer's real Codex auth into the host-side test environment.
+// ChatGPT-specific tests below override CODEX_HOME with a fixture dir.
+process.env.CODEX_HOME = process.env.CODEX_HOME || mkdtempSync(join(tmpdir(), 'dsh-qp-test-'));
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const plugin = await import(`file://${join(root, 'lib/index.js')}`);
@@ -438,6 +445,105 @@ try {
 		&& !/AWS4/.test(codeOnly)
 	);
 }
+// ---------- A2c: ChatGPT subscription (Codex OAuth, ~/.codex/auth.json) ----------
+// The row auto-discovers only when CODEX_HOME/auth.json exists. We point
+// CODEX_HOME at a temp fixture and stub fetch for the wham/usage endpoint.
+const codexFixture = mkdtempSync(join(tmpdir(), 'dsh-qp-codex-'));
+writeFileSync(join(codexFixture, 'auth.json'), JSON.stringify({
+	auth_mode: 'chatgpt',
+	tokens: {
+		access_token: 'eyJ.fake-access',
+		refresh_token: 'rt-fake',
+		account_id: 'acct-test-123',
+		expires_at: Math.floor(Date.now() / 1000) + 3600
+	}
+}));
+const prevCodexHome = process.env.CODEX_HOME;
+process.env.CODEX_HOME = codexFixture;
+// Re-import the plugin module fresh so it reads the new CODEX_HOME (the path
+// helpers are evaluated lazily, but the catalog endpoint constant is set at
+// load — it is constant regardless, so a plain apply() suffices).
+let cgHandler;
+{
+	const cgRegs = [];
+	const cgCtx = {
+		connection: { rpc: { handle: (ch, h) => { cgRegs.push({ ch, h }); return async () => {}; } } },
+		credentials: { resolve: async () => undefined }
+	};
+	plugin.apply(cgCtx, {});
+	cgHandler = cgRegs[0].h;
+}
+const cgSpecs = await cgHandler('specs', null, undefined);
+check('A: chatgpt row discovered when auth.json exists', (() => {
+	const row = cgSpecs.value.rows.find((r) => r.id === 'chatgpt');
+	return !!row && row.kind === 'usage' && row.windowLabels?.rolling === '5h' && row.windowLabels?.weekly === '周';
+})());
+check('A: chatgpt row leaks no credential/endpoint', (() => {
+	const text = JSON.stringify(cgSpecs);
+	return !text.includes('fake-access') && !text.includes('auth.json') && !text.includes('endpoint');
+})());
+// Stub fetch: first call returns a Plus weekly window, second (for refresh test) 401.
+let cgCallCount = 0;
+globalThis.fetch = async (url, init) => {
+	const s = String(url);
+	cgCallCount++;
+	if (s.includes('backend-api/wham/usage')) {
+		return {
+			ok: true, status: 200,
+			json: async () => ({
+				plan_type: 'plus',
+				rate_limit: {
+					allowed: true, limit_reached: false,
+					primary_window: { used_percent: 42, limit_window_seconds: 604800, reset_at: 1787833892 },
+					secondary_window: null
+				},
+				credits: { has_credits: false, unlimited: false, balance: '0' }
+			})
+		};
+	}
+	return { ok: false, status: 404, json: async () => ({}) };
+};
+let cgFetch;
+try { cgFetch = await cgHandler('fetch-all', {}, undefined); } finally { globalThis.fetch = realFetch; }
+check('A: chatgpt plus -> weekly usage window parsed', (() => {
+	const row = cgFetch.value.rows.find((r) => r.id === 'chatgpt');
+	return row?.view?.kind === 'usage'
+		&& row.view.windows?.weekly?.percent === 42
+		&& row.view.windows?.rolling === undefined
+		&& typeof row.view.windows?.weekly?.resetsAt === 'string'
+		&& /plan: plus/.test(row.view.title);
+})());
+// Pro plan (secondary 5h window present)
+globalThis.fetch = async (url) => {
+	if (String(url).includes('backend-api/wham/usage')) {
+		return {
+			ok: true, status: 200,
+			json: async () => ({
+				plan_type: 'pro',
+				rate_limit: {
+					allowed: true, limit_reached: false,
+					primary_window: { used_percent: 60, limit_window_seconds: 604800, reset_at: 1787833892 },
+					secondary_window: { used_percent: 25, limit_window_seconds: 18000, reset_at: 1787400000 }
+				}
+			})
+		};
+	}
+	return { ok: false, status: 404, json: async () => ({}) };
+};
+let cgPro;
+try { cgPro = await cgHandler('fetch-all', {}, undefined); } finally { globalThis.fetch = realFetch; }
+check('A: chatgpt pro -> weekly + 5h (rolling) windows', (() => {
+	const row = cgPro.value.rows.find((r) => r.id === 'chatgpt');
+	return row?.view?.windows?.weekly?.percent === 60 && row?.view?.windows?.rolling?.percent === 25;
+})());
+// Missing auth.json -> row hidden (probes file existence)
+process.env.CODEX_HOME = mkdtempSync(join(tmpdir(), 'dsh-qp-nocodex-'));
+const noRegs = [];
+const noCtx = { connection: { rpc: { handle: (ch, h) => { noRegs.push({ ch, h }); return async () => {}; } } }, credentials: { resolve: async () => undefined } };
+plugin.apply(noCtx, {});
+const noSpecs = await noRegs[0].h('specs', null, undefined);
+check('A: chatgpt hidden when auth.json does not exist', !noSpecs.value.rows.some((r) => r.id === 'chatgpt'));
+process.env.CODEX_HOME = prevCodexHome;
 
 // ---------- A2d: search lane unknown / absent weekly (no fabricated 0%) ----------
 credentialMap = { ZAI_CODING_CN_API_KEY: 'sk-zai-cn', ZAI_API_KEY: 'sk-zai', KIMI_API_KEY: 'sk-kimi', MINIMAX_CN_API_KEY: 'sk-mmcn', ZHIPU_API_KEY: 'sk-zp' };

--- a/src/client.ts
+++ b/src/client.ts
@@ -90,7 +90,23 @@
 				warnPercentPH: "预警 %（默认 {n}）",
 				warnBalancePH: "预警 {cur}（默认 {n}）",
 				localOnly: "设置仅保存在本浏览器",
-				resetDefaults: "恢复默认"
+				resetDefaults: "恢复默认",
+				chatgptAccount: "ChatGPT 账号",
+				chatgptLogin: "登录 ChatGPT",
+				chatgptLogout: "退出登录",
+				chatgptLoggedIn: "已登录（{source}）",
+				chatgptSourceDsh: "插件内登录",
+				chatgptSourceCodex: "Codex CLI",
+				chatgptPlan: "套餐：{plan}",
+				chatgptLoginHint: "未登录。点下方按钮，在浏览器用 ChatGPT 账号授权即可，无需安装 Codex CLI。",
+				chatgptLoginStep1: "1. 打开此链接并登录：",
+				chatgptLoginStep2: "2. 输入一次性验证码（15 分钟内有效）：",
+				chatgptWaiting: "等待浏览器授权中…",
+				chatgptLoginFailed: "登录失败：{msg}",
+				chatgptCopy: "复制",
+				chatgptCopied: "已复制",
+				chatgptOpenLink: "打开链接",
+				chatgptCancel: "取消"
 			},
 			en: {
 				title: "Model quota",
@@ -138,7 +154,23 @@
 				warnPercentPH: "Warn % (default {n})",
 				warnBalancePH: "Warn {cur} (default {n})",
 				localOnly: "Stored in this browser only",
-				resetDefaults: "Reset defaults"
+				resetDefaults: "Reset defaults",
+				chatgptAccount: "ChatGPT account",
+				chatgptLogin: "Log in to ChatGPT",
+				chatgptLogout: "Log out",
+				chatgptLoggedIn: "Signed in ({source})",
+				chatgptSourceDsh: "in-plugin login",
+				chatgptSourceCodex: "Codex CLI",
+				chatgptPlan: "Plan: {plan}",
+				chatgptLoginHint: "Not signed in. Click below and authorize with your ChatGPT account in the browser — no Codex CLI install required.",
+				chatgptLoginStep1: "1. Open this link and sign in:",
+				chatgptLoginStep2: "2. Enter this one-time code (valid for 15 minutes):",
+				chatgptWaiting: "Waiting for browser authorization…",
+				chatgptLoginFailed: "Login failed: {msg}",
+				chatgptCopy: "Copy",
+				chatgptCopied: "Copied",
+				chatgptOpenLink: "Open link",
+				chatgptCancel: "Cancel"
 			}
 		};
 
@@ -206,7 +238,11 @@
 			'#dsh-quota-card .dsh-setting-hint{color:var(--dsw-alias-label-tertiary,#818590);font-size:11px;line-height:16px}',
 			'#dsh-quota-card .dsh-setting-reset{padding:3px 10px;border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.14));border-radius:8px;background:transparent;color:var(--dsw-alias-label-secondary,#61666b);font:inherit;font-size:12px;line-height:18px;cursor:pointer;transition:color 120ms ease,background-color 120ms ease}',
 			'#dsh-quota-card .dsh-setting-proxy{width:150px}',
-			'#dsh-quota-card .dsh-setting-reset:hover{color:var(--dsw-alias-label-primary,#1b1b1c);background:var(--dsw-alias-interactive-bg-hover,rgba(0,0,0,.05))}'
+			'#dsh-quota-card .dsh-setting-reset:hover{color:var(--dsw-alias-label-primary,#1b1b1c);background:var(--dsw-alias-interactive-bg-hover,rgba(0,0,0,.05))}',
+			'#dsh-quota-card .dsh-chatgpt-row{align-self:stretch}',
+			'#dsh-quota-card .dsh-chatgpt-url a{color:var(--dsw-alias-brand,#3b82f6);font-size:11px;word-break:break-all}',
+			'#dsh-quota-card .dsh-chatgpt-code-row{display:flex;align-items:center;gap:8px}',
+			'#dsh-quota-card .dsh-chatgpt-code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:16px;font-weight:600;letter-spacing:2px;padding:4px 10px;border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.14));border-radius:8px;background:var(--dsw-alias-bg-raised,rgba(0,0,0,.03))}'
 		].join("\n");
 
 		var CAPSULE_CHOICES = [
@@ -434,12 +470,130 @@
 				React.createElement("div", { className: "dsh-provider-main" }, children));
 		}
 
+		/**
+		 * ChatGPT account section. Self-contained: it queries the host's
+		 * chatgpt-auth-* RPC endpoints and renders either a login button
+		 * (which kicks off the device-code flow and shows the one-time code +
+		 * verification URL) or a signed-in state with a log-out button.
+		 * Secrets never reach this component — only status and codes.
+		 */
+		function ChatGPTAccount(props) {
+			var t = props.t;
+			var call = props.call;
+			var statusState = React.useState(null);
+			var status = statusState[0], setStatus = statusState[1];
+			var busyState = React.useState(false);
+			var busy = busyState[0], setBusy = busyState[1];
+			var errorState = React.useState(null);
+			var errorMsg = errorState[0], setError = errorState[1];
+			var copiedState = React.useState(false);
+			var copied = copiedState[0], setCopied = copiedState[1];
+			var pollRef = React.useRef(null);
+
+			function sourceLabel(src) {
+				return src === "codex" ? t("chatgptSourceCodex") : t("chatgptSourceDsh");
+			}
+			function refresh() {
+				return call("chatgpt-auth-status", null).then(function (r) {
+					if (r && r.ok) setStatus(r.value);
+				}).catch(function () { /* host may be mid-load */ });
+			}
+			React.useEffect(function () {
+				refresh();
+				// While a login is in-flight, poll for completion; the host
+				// flips `login.active` to false when it obtains tokens.
+				var timer = setInterval(function () {
+					call("chatgpt-auth-status", null).then(function (r) {
+						if (r && r.ok) {
+							setStatus(r.value);
+							if (!r.value.login || !r.value.login.active) {
+								setBusy(false);
+							}
+						}
+					}).catch(function () {});
+				}, 2500);
+				pollRef.current = timer;
+				return function () { clearInterval(timer); };
+			}, []);
+
+			function startLogin() {
+				setError(null);
+				setBusy(true);
+				call("chatgpt-login-start", null).then(function (r) {
+					if (!r || !r.ok) {
+						setBusy(false);
+						setError((r && r.error && r.error.message) || "failed");
+					}
+					// The host returns { verificationUrl, userCode }; refresh
+					// status so the in-flight code renders.
+					return refresh();
+				}).catch(function (e) {
+					setBusy(false);
+					setError(String(e && e.message ? e.message : e));
+				});
+			}
+			function cancelLogin() {
+				call("chatgpt-login-cancel", null).then(function () { setBusy(false); return refresh(); });
+			}
+			function logout() {
+				call("chatgpt-logout", null).then(function () { return refresh(); });
+			}
+			function copyCode(code) {
+				try {
+					navigator.clipboard.writeText(code).then(function () {
+						setCopied(true);
+						setTimeout(function () { setCopied(false); }, 1500);
+					}).catch(function () {});
+				} catch (e) { /* clipboard may be unavailable */ }
+			}
+
+			var login = status && status.login;
+			var inFlight = busy || (login && login.active);
+			var children = [];
+			if (status && status.loggedIn && !(login && login.active)) {
+				children.push(React.createElement("div", { key: "in", className: "dsh-setting-hint" },
+					t("chatgptLoggedIn", { source: sourceLabel(status.source) })
+						+ (status.plan_type ? " · " + t("chatgptPlan", { plan: status.plan_type }) : "")));
+				children.push(React.createElement("button", {
+					key: "out", className: "dsh-setting-reset", type: "button", onClick: logout
+				}, t("chatgptLogout")));
+			} else if (inFlight && login && login.userCode) {
+				children.push(React.createElement("div", { key: "s1", className: "dsh-setting-hint" }, t("chatgptLoginStep1")));
+				children.push(React.createElement("div", { key: "url", className: "dsh-chatgpt-url" },
+					React.createElement("a", { href: login.verificationUrl, target: "_blank", rel: "noreferrer" }, login.verificationUrl)));
+				children.push(React.createElement("div", { key: "s2", className: "dsh-setting-hint", style: { marginTop: "6px" } }, t("chatgptLoginStep2")));
+				children.push(React.createElement("div", { key: "code", className: "dsh-chatgpt-code-row" },
+					React.createElement("span", { className: "dsh-chatgpt-code" }, login.userCode),
+					React.createElement("button", {
+						className: "dsh-setting-reset", type: "button", onClick: function () { copyCode(login.userCode); }
+					}, copied ? t("chatgptCopied") : t("chatgptCopy"))));
+				children.push(React.createElement("div", { key: "wait", className: "dsh-setting-hint", style: { marginTop: "6px" } }, t("chatgptWaiting")));
+				children.push(React.createElement("button", {
+					key: "cancel", className: "dsh-setting-reset", type: "button", style: { marginTop: "6px" }, onClick: cancelLogin
+				}, t("chatgptCancel")));
+			} else {
+				children.push(React.createElement("div", { key: "hint", className: "dsh-setting-hint" }, t("chatgptLoginHint")));
+				if (errorMsg) {
+					children.push(React.createElement("div", { key: "err", className: "dsh-setting-hint", style: { color: "#e5484d" } },
+						t("chatgptLoginFailed", { msg: errorMsg })));
+				}
+				children.push(React.createElement("button", {
+					key: "in", className: "dsh-setting-reset", type: "button", disabled: busy, onClick: startLogin
+				}, t("chatgptLogin")));
+			}
+			return React.createElement("div", { className: "dsh-setting-section" },
+				React.createElement("div", { className: "dsh-setting-title" }, t("chatgptAccount")),
+				React.createElement("div", { className: "dsh-setting-row dsh-chatgpt-row", style: { flexDirection: "column", alignItems: "stretch", gap: "6px" } },
+					children));
+		}
+
 		function SettingsPanel(props) {
 			var specs = props.specs;
 			var settings = props.settings;
 			var onChange = props.onChange;
 			var onReset = props.onReset;
 			var t = props.t;
+			var call = props.call;
 
 			var toggle = function (id) {
 				var hidden = Object.assign({}, settings.hidden);
@@ -524,6 +678,7 @@
 			});
 
 			return React.createElement("div", { className: "dsh-quota-settings" },
+				React.createElement(ChatGPTAccount, { key: "chatgpt", t: t, call: call }),
 				React.createElement("div", { className: "dsh-setting-section" },
 					React.createElement("div", { className: "dsh-setting-title" }, t("settingsProviders")),
 					visibilityRows.length ? visibilityRows : React.createElement("div", { className: "dsh-setting-hint" }, t("settingsNoProviders"))),
@@ -688,9 +843,12 @@
 					return function () { globalThis.removeEventListener("resize", reclamp); };
 				}, [panelPos ? panelPos.x + ":" + panelPos.y : ""]);
 
+				var call = function (endpoint, payload) {
+					return ctx.connection.rpc.call(CHANNEL, endpoint, payload);
+				};
+
 				var loadSpecs = function () {
-					return ctx.connection.rpc.call(CHANNEL, "specs", null).then(function (result) {
-						if (result && result.ok === true && result.value && Array.isArray(result.value.rows)) {
+					return ctx.connection.rpc.call(CHANNEL, "specs", null).then(function (result) {						if (result && result.ok === true && result.value && Array.isArray(result.value.rows)) {
 							setSpecs(result.value);
 						} else {
 							setLoadError(result && result.error ? result.error.message : t("loadFailed"));
@@ -803,6 +961,7 @@
 					bodyChildren.push(React.createElement(SettingsPanel, {
 						key: "settings",
 						t: t,
+						call: call,
 						specs: specs,
 						settings: settings,
 						onChange: updateSettings,

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,9 @@
  * repo's real path, which cannot walk up to dsh's bundled packages.
  */
 import crypto from 'node:crypto';
+import { promises as fsp } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import http from 'node:http';
 import https from 'node:https';
 import net from 'node:net';
@@ -189,6 +192,92 @@ function volcengineSignedHeaders(ak: string, sk: string, region: string, action:
 	};
 }
 
+// ── ChatGPT subscription (Codex OAuth) usage ────────────────
+//
+// ChatGPT Plus/Pro/Business plans have no public usage API, but the
+// official open-source Codex CLI authenticates against an EXPERIMENTAL
+// internal endpoint that returns the current plan's rate-limit windows:
+//
+//   GET https://chatgpt.com/backend-api/wham/usage
+//   Authorization: Bearer <ChatGPT OAuth access_token>
+//   ChatGPT-Account-Id: <account_id>
+//
+// Tokens live in `~/.codex/auth.json` (written by `codex login`). The
+// access token is short-lived; we refresh it via the standard OAuth
+// token endpoint using the refresh_token from the same file. The
+// refreshed tokens are kept in an in-memory cache only — we do NOT
+// write back to auth.json, because that file is owned by the Codex CLI
+// (matching the ownership boundary CodexBar documents).
+//
+// This adapter is explicitly experimental: the endpoint/shape are not
+// a public contract and may drift. Field names are verified against
+// live responses (2026-08) and the openai/codex client.
+const CHATGPT_USAGE_URL = 'https://chatgpt.com/backend-api/wham/usage';
+const CHATGPT_TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const CHATGPT_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+/** Directory containing auth.json; honors CODEX_HOME like the Codex CLI. */
+function chatgptCodexHome(): string {
+	const override = process.env.CODEX_HOME;
+	return override && override.length > 0 ? override : path.join(os.homedir(), '.codex');
+}
+/** Absolute path to the Codex auth.json. Resolved lazily so tests can steer via CODEX_HOME. */
+function chatgptAuthJsonPath(): string {
+	return path.join(chatgptCodexHome(), 'auth.json');
+}
+/** Returns true when the local Codex auth file exists (row auto-discovery probe). */
+async function chatgptAuthExists(): Promise<boolean> {
+	try {
+		await fsp.access(chatgptAuthJsonPath());
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+interface ChatGPTTokenBundle {
+	access_token: string;
+	refresh_token?: string;
+	id_token?: string;
+	account_id?: string;
+	/** epoch ms when the access token expires (if known). */
+	expires_at_ms?: number;
+}
+
+/** In-memory token cache; refreshed on expiry or on auth failure. */
+let chatgptTokenCache: { bundle: ChatGPTTokenBundle } | null = null;
+
+async function readChatGPTAuthFile(): Promise<ChatGPTTokenBundle> {
+	const authJson = chatgptAuthJsonPath();
+	let raw: string;
+	try {
+		raw = await fsp.readFile(authJson, 'utf8');
+	} catch (err) {
+		throw new Error(`ChatGPT: cannot read ${authJson} (run "codex login" first): ${(err as Error).message}`);
+	}
+	let parsed: any;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		throw new Error(`ChatGPT: ${authJson} is not valid JSON`);
+	}
+	const tokens = parsed?.tokens;
+	if (!tokens || typeof tokens !== 'object' || typeof tokens.access_token !== 'string' || tokens.access_token.length === 0) {
+		throw new Error(`ChatGPT: ${authJson} has no tokens.access_token (run "codex login")`);
+	}
+	let expires_at_ms: number | undefined;
+	if (typeof tokens.expires_at === 'number' && Number.isFinite(tokens.expires_at) && tokens.expires_at > 0) {
+		// Codex writes epoch seconds; tolerate ms.
+		expires_at_ms = tokens.expires_at > 1e12 ? tokens.expires_at : tokens.expires_at * 1000;
+	}
+	return {
+		access_token: tokens.access_token,
+		refresh_token: typeof tokens.refresh_token === 'string' ? tokens.refresh_token : undefined,
+		id_token: typeof tokens.id_token === 'string' ? tokens.id_token : undefined,
+		account_id: typeof tokens.account_id === 'string' ? tokens.account_id : undefined,
+		expires_at_ms
+	};
+}
+
 /**
  * Call one Volcengine Ark OpenAPI action (POST with empty body, signed).
  * Volcengine returns business errors as 200 + ResponseMetadata.Error, so
@@ -221,6 +310,126 @@ async function volcengineCall(action: string, region: string, ak: string, sk: st
 }
 
 /**
+ * Exchange a refresh_token for a fresh access token at the OpenAI OAuth
+ * endpoint. Form-urlencoded as required by the OAuth2 token endpoint.
+ */
+async function refreshChatGPTToken(refreshToken: string, timeoutMs: number): Promise<ChatGPTTokenBundle> {
+	const body = new URLSearchParams({
+		grant_type: 'refresh_token',
+		refresh_token: refreshToken,
+		client_id: CHATGPT_CLIENT_ID
+	}).toString();
+	const res = await fetch(CHATGPT_TOKEN_URL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body,
+		signal: AbortSignal.timeout(timeoutMs)
+	});
+	const json: any = await res.json().catch(() => null);
+	if (!res.ok || json === null) {
+		const msg = json?.error_description || json?.error || `HTTP ${res.status}`;
+		throw new Error(`ChatGPT token refresh failed: ${msg}`);
+	}
+	if (typeof json.access_token !== 'string' || json.access_token.length === 0) {
+		throw new Error('ChatGPT token refresh response missing access_token');
+	}
+	const expiresIn = Number(json.expires_in);
+	return {
+		access_token: json.access_token,
+		refresh_token: typeof json.refresh_token === 'string' ? json.refresh_token : refreshToken,
+		id_token: typeof json.id_token === 'string' ? json.id_token : undefined,
+		expires_at_ms: Number.isFinite(expiresIn) && expiresIn > 0 ? Date.now() + expiresIn * 1000 : undefined
+	};
+}
+
+/**
+ * Resolve a usable access token: cache hit while fresh, else reload from
+ * auth.json (which Codex may have refreshed in the meantime), else refresh
+ * via the OAuth endpoint using the stored refresh_token. Refreshed tokens
+ * are cached in memory only.
+ */
+async function resolveChatGPTToken(timeoutMs: number): Promise<{ accessToken: string; accountId?: string }> {
+	const now = Date.now();
+	const cached = chatgptTokenCache?.bundle;
+	if (cached && cached.access_token && (!cached.expires_at_ms || cached.expires_at_ms - now > 30_000)) {
+		return { accessToken: cached.access_token, accountId: cached.account_id };
+	}
+	const fromDisk = await readChatGPTAuthFile();
+	if (!fromDisk.expires_at_ms || fromDisk.expires_at_ms - now > 30_000) {
+		chatgptTokenCache = { bundle: fromDisk };
+		return { accessToken: fromDisk.access_token, accountId: fromDisk.account_id };
+	}
+	// Disk token is expired/near-expiry — refresh.
+	if (!fromDisk.refresh_token) {
+		throw new Error('ChatGPT: access token expired and auth.json has no refresh_token — run "codex login" again');
+	}
+	const refreshed = await refreshChatGPTToken(fromDisk.refresh_token, timeoutMs);
+	if (!refreshed.account_id) refreshed.account_id = fromDisk.account_id;
+	chatgptTokenCache = { bundle: refreshed };
+	return { accessToken: refreshed.access_token, accountId: refreshed.account_id };
+}
+
+/**
+ * Call the experimental ChatGPT usage endpoint. On a 401 the caller may
+ * retry once after forcing a token refresh.
+ */
+async function fetchChatGPTUsage(accessToken: string, accountId: string | undefined, timeoutMs: number): Promise<any> {
+	const headers: Record<string, string> = {
+		'Authorization': `Bearer ${accessToken}`,
+		'Accept': 'application/json'
+	};
+	if (accountId) headers['ChatGPT-Account-Id'] = accountId;
+	const res = await fetch(CHATGPT_USAGE_URL, { headers, signal: AbortSignal.timeout(timeoutMs) });
+	const body: any = await res.json().catch(() => null);
+	if (res.status === 401) {
+		const err: any = new Error('ChatGPT: access token rejected (401)');
+		err.code = 'chatgpt-auth';
+		throw err;
+	}
+	if (body === null) throw new Error(`ChatGPT: HTTP ${res.status} non-JSON response`);
+	if (!res.ok) throw new Error(`ChatGPT: HTTP ${res.status}: ${body?.detail || body?.error || 'unknown error'}`);
+	return body;
+}
+
+/**
+ * Normalize a wham/usage response into the plugin's usage view.
+ * primary_window is the weekly allowance; secondary_window (Pro plans)
+ * is the shorter 5h window. We surface primary as `weekly` and, when
+ * present, secondary as `rolling`, matching the coding-plan convention.
+ */
+function parseChatGPTUsage(body: any): { kind: 'usage'; windows: Record<string, any>; title: string } | null {
+	const rl = body?.rate_limit;
+	if (!rl || typeof rl !== 'object') return null;
+	const toIso = (epochSec: unknown) => {
+		const n = Number(epochSec);
+		if (!Number.isFinite(n) || n <= 0) return undefined;
+		return new Date(n > 1e12 ? n : n * 1000).toISOString();
+	};
+	const mapWindow = (w: any) => {
+		if (!w || typeof w !== 'object') return null;
+		const pct = Number(w.used_percent);
+		if (!Number.isFinite(pct)) return null;
+		return {
+			percent: Math.min(100, Math.max(0, Math.round(pct))),
+			resetsAt: toIso(w.reset_at)
+		};
+	};
+	const windows: Record<string, any> = {};
+	const primary = mapWindow(rl.primary_window);
+	if (primary) windows.weekly = primary;
+	const secondary = mapWindow(rl.secondary_window);
+	if (secondary) windows.rolling = secondary;
+	if (Object.keys(windows).length === 0) return null;
+	const plan = typeof body?.plan_type === 'string' && body.plan_type ? body.plan_type : 'subscription';
+	const titleParts = [
+		`plan: ${plan}`,
+		windows.rolling ? `5h: ${windows.rolling.percent}%` : null,
+		windows.weekly ? `weekly: ${windows.weekly.percent}%` : null
+	].filter(Boolean);
+	return { kind: 'usage', windows, title: titleParts.join('\n') };
+}
+
+/**
  * Normalized row views an adapter may produce. The browser half renders
  * these generically; upstream response schema details never leave the host.
  * @typedef {object} RowView
@@ -248,7 +457,8 @@ const FORMAT_META = {
 	'opencode-usage': { kind: 'usage' },
 	'zai-coding-quota': { kind: 'usage' },
 	'kimi-coding-usage': { kind: 'usage' },
-	'volcengine-usage': { kind: 'usage' }
+	'volcengine-usage': { kind: 'usage' },
+	'chatgpt-subscription': { kind: 'usage' }
 };
 
 /**
@@ -275,11 +485,17 @@ const CATALOG = [
 	// OpenAPI control plane. Unlike every other catalog row this one
 	// authenticates with an AK/SK pair (signed, not Bearer) —
 	// `secretRefs` is the second credential and fetchRow signs the request.
-	{ id: 'volcengine', label: 'Volcengine Ark', refs: ['VOLC_ACCESS_KEY'], secretRefs: ['VOLC_SECRET_KEY'], endpoint: 'https://open.volcengineapi.com', format: 'volcengine-usage', windowLabels: { rolling: '5h', weekly: '周', monthly: '月' } }
+	{ id: 'volcengine', label: 'Volcengine Ark', refs: ['VOLC_ACCESS_KEY'], secretRefs: ['VOLC_SECRET_KEY'], endpoint: 'https://open.volcengineapi.com', format: 'volcengine-usage', windowLabels: { rolling: '5h', weekly: '周', monthly: '月' } },
+	// ChatGPT subscription (Plus/Pro/Business via Codex OAuth). Unlike every
+	// other row this does NOT use ctx.credentials: tokens are read from
+	// ~/.codex/auth.json (written by `codex login`) and refreshed host-side.
+	// `localAuth: 'codex'` makes resolveRows skip credential probing and always
+	// surface the row (the row errors at fetch time if auth.json is missing).
+	{ id: 'chatgpt', label: 'ChatGPT', localAuth: 'codex', endpoint: CHATGPT_USAGE_URL, format: 'chatgpt-subscription', windowLabels: { rolling: '5h', weekly: '周' } }
 ];
 
 /** Keys a `catalog` override may set on an auto-discovered row. */
-const CATALOG_OVERRIDE_KEYS = ['label', 'endpoint', 'format', 'proxy', 'refs', 'secretRefs', 'currency', 'balanceTiers', 'warnPercent', 'errorPercent', 'windowLabels'];
+const CATALOG_OVERRIDE_KEYS = ['label', 'endpoint', 'format', 'proxy', 'refs', 'secretRefs', 'currency', 'balanceTiers', 'warnPercent', 'errorPercent', 'windowLabels', 'localAuth'];
 
 /**
  * Format adapters: upstream JSON → RowView. Each returns a view or throws
@@ -496,6 +712,11 @@ const FORMATS = {
 	// format is registered in FORMATS/FORMAT_META for config validation.
 	'volcengine-usage': () => {
 		throw new Error('volcengine-usage is handled inline by fetchRow');
+	},
+	// chatgpt-subscription is dispatched inline in fetchRow because it uses
+	// an OAuth token from ~/.codex/auth.json (with refresh), not ctx.credentials.
+	'chatgpt-subscription': () => {
+		throw new Error('chatgpt-subscription is handled inline by fetchRow');
 	}
 };
 
@@ -515,17 +736,18 @@ export const Config = z.object({
 		label: z.string().required(),
 		credential: z.string().role('credential-ref').required(),
 		secretCredential: z.string().role('credential-ref'),
+		region: z.string(),
+		localAuth: z.union([z.const('codex')]),
 		endpoint: z.string().pattern(HTTP_URL_PATTERN).required(),
 		format: z.union([
 			z.const('deepseek-balance'), z.const('openrouter-credits'), z.const('siliconflow-balance'),
 			z.const('moonshot-balance'), z.const('minimax-remains'), z.const('stepfun-accounts'),
 			z.const('xai-credits'), z.const('openai-billing'), z.const('zhipu-quota'),
 			z.const('opencode-usage'), z.const('zai-coding-quota'), z.const('kimi-coding-usage'),
-			z.const('volcengine-usage')
+			z.const('volcengine-usage'), z.const('chatgpt-subscription')
 		]).default('deepseek-balance'),
 		proxy: z.string(),
 		currency: z.string(),
-		region: z.string(),
 		balanceTiers: z.object({
 			critical: z.number().default(10),
 			warn: z.number().default(20),
@@ -820,24 +1042,40 @@ async function resolveRows(ctx, raw) {
 			if (raw.hide.includes(entry.id) || explicitIds.has(entry.id)) continue;
 			const override = raw.catalog[entry.id] || {};
 			const merged = { ...entry, ...override };
-			const hit = await firstResolvedRef(ctx, merged.refs);
-			if (!hit) continue;
-			// Two-credential rows (e.g. Volcengine AK/SK): the row is only
-			// discoverable once BOTH refs resolve. The resolved ref NAME is
-			// stored (not the value); fetchRow re-resolves per cycle.
+
+			let credentialRef: string | undefined;
 			let secretCredential: string | undefined;
-			if (Array.isArray(merged.secretRefs) && merged.secretRefs.length > 0) {
-				const secretHit = await firstResolvedRef(ctx, merged.secretRefs);
-				if (!secretHit) continue;
-				secretCredential = secretHit.ref;
+
+			if (merged.localAuth) {
+				// localAuth rows (ChatGPT via ~/.codex/auth.json) probe the
+				// local auth source each cycle; they join the panel only when
+				// that source exists. They surface their own fetch error if
+				// the file later disappears or is malformed.
+				if (merged.localAuth === 'codex' && !(await chatgptAuthExists())) continue;
+				credentialRef = undefined;
+			} else {
+				// Bearer/key rows: the primary ref must resolve. Two-credential
+				// rows (e.g. Volcengine AK/SK) require BOTH refs; the resolved
+				// ref NAME is stored (not the value); fetchRow re-resolves per
+				// cycle.
+				const hit = await firstResolvedRef(ctx, merged.refs);
+				if (!hit) continue;
+				credentialRef = hit.ref;
+				if (Array.isArray(merged.secretRefs) && merged.secretRefs.length > 0) {
+					const secretHit = await firstResolvedRef(ctx, merged.secretRefs);
+					if (!secretHit) continue;
+					secretCredential = secretHit.ref;
+				}
 			}
+
 			const at = `quota-panel: config.catalog.${entry.id}`;
 			rows.push({
 				id: merged.id,
 				label: merged.label,
-				credential: hit.ref,
+				credential: credentialRef,
 				secretCredential,
 				region: merged.region,
+				localAuth: merged.localAuth,
 				endpoint: merged.endpoint,
 				format: merged.format,
 				proxy: merged.proxy,
@@ -958,6 +1196,37 @@ function adaptRow(format, body) {
  */
 async function fetchRow(ctx, provider, proxies, clientProxyUrl) {
 	try {
+		// ── ChatGPT subscription (Codex OAuth) ──────────────────
+		// Reads tokens from ~/.codex/auth.json, refreshes host-side,
+		// and queries the experimental wham/usage endpoint. On a 401
+		// we force a single token refresh retry.
+		if (provider.format === 'chatgpt-subscription') {
+			try {
+				let { accessToken, accountId } = await resolveChatGPTToken(UPSTREAM_TIMEOUT_MS);
+				let body: any;
+				try {
+					body = await fetchChatGPTUsage(accessToken, accountId, UPSTREAM_TIMEOUT_MS);
+				} catch (e) {
+					if ((e as any)?.code === 'chatgpt-auth') {
+						// Drop the cached token and refresh once.
+						chatgptTokenCache = null;
+						const refreshed = await resolveChatGPTToken(UPSTREAM_TIMEOUT_MS);
+						accessToken = refreshed.accessToken;
+						accountId = refreshed.accountId;
+						body = await fetchChatGPTUsage(accessToken, accountId, UPSTREAM_TIMEOUT_MS);
+					} else {
+						throw e;
+					}
+				}
+				const view = parseChatGPTUsage(body);
+				if (!view) {
+					return { id: provider.id, error: 'ChatGPT: no rate_limit data in usage response' };
+				}
+				return { id: provider.id, view };
+			} catch (e) {
+				return { id: provider.id, error: String((e && (e as Error).message) || e) };
+			}
+		}
 		const hit = await ctx.credentials.resolve(provider.credential);
 		if (!hit || typeof hit.value !== 'string' || hit.value.length === 0) {
 			return { id: provider.id, error: `${provider.credential} is not configured` };

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,20 +202,35 @@ function volcengineSignedHeaders(ak: string, sk: string, region: string, action:
 //   Authorization: Bearer <ChatGPT OAuth access_token>
 //   ChatGPT-Account-Id: <account_id>
 //
-// Tokens live in `~/.codex/auth.json` (written by `codex login`). The
-// access token is short-lived; we refresh it via the standard OAuth
-// token endpoint using the refresh_token from the same file. The
-// refreshed tokens are kept in an in-memory cache only — we do NOT
-// write back to auth.json, because that file is owned by the Codex CLI
-// (matching the ownership boundary CodexBar documents).
+// Two login methods are supported (resolveChatGPTToken tries them in order):
+//
+//   1. DSH-managed device-code login (no Codex CLI needed): the plugin
+//      runs the same OAuth 2.0 device-authorization flow Codex uses and
+//      persists tokens to $DSH_HOME/dsh-quota-panel/chatgpt-auth.json.
+//      The settings panel has a "Log in to ChatGPT" button that shows a
+//      one-time code + verification URL; the host polls and exchanges
+//      the authorization code (with PKCE) for tokens.
+//
+//   2. Codex CLI auth.json fallback: if the user has already logged in
+//      via `codex login`, tokens are read from ~/.codex/auth.json (or
+//      $CODEX_HOME/auth.json). This path never writes back to the file
+//      (Codex CLI owns it); refreshed tokens stay in process memory.
+//
+// Either way, the access token is refreshed host-side via the standard
+// OAuth token endpoint using the refresh_token; tokens never reach the
+// browser (rowSpec only forwards display fields).
 //
 // This adapter is explicitly experimental: the endpoint/shape are not
 // a public contract and may drift. Field names are verified against
 // live responses (2026-08) and the openai/codex client.
 const CHATGPT_USAGE_URL = 'https://chatgpt.com/backend-api/wham/usage';
 const CHATGPT_TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const CHATGPT_USERCODE_URL = 'https://auth.openai.com/api/accounts/deviceauth/usercode';
+const CHATGPT_DEVICETOKEN_URL = 'https://auth.openai.com/api/accounts/deviceauth/token';
+const CHATGPT_DEVICE_REDIRECT_URI = 'https://auth.openai.com/deviceauth/callback';
+const CHATGPT_DEVICE_VERIFY_URL = 'https://auth.openai.com/codex/device';
 const CHATGPT_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
-/** Directory containing auth.json; honors CODEX_HOME like the Codex CLI. */
+/** Directory containing the Codex auth.json; honors CODEX_HOME like the Codex CLI. */
 function chatgptCodexHome(): string {
 	const override = process.env.CODEX_HOME;
 	return override && override.length > 0 ? override : path.join(os.homedir(), '.codex');
@@ -224,8 +239,33 @@ function chatgptCodexHome(): string {
 function chatgptAuthJsonPath(): string {
 	return path.join(chatgptCodexHome(), 'auth.json');
 }
-/** Returns true when the local Codex auth file exists (row auto-discovery probe). */
+
+/**
+ * Directory for the DSH-managed ChatGPT token store. Honors DSH_HOME
+ * (set by the harness), falling back to ~/.dsh. The file mode is
+ * restricted to the current user where the platform supports it.
+ */
+function chatgptDshStoreDir(): string {
+	const home = process.env.DSH_HOME;
+	return home && home.length > 0 ? home : path.join(os.homedir(), '.dsh');
+}
+function chatgptDshStorePath(): string {
+	return path.join(chatgptDshStoreDir(), 'dsh-quota-panel', 'chatgpt-auth.json');
+}
+/** Returns true when the Codex auth.json exists (distinct from DSH store). */
+async function codexAuthFileExists(): Promise<boolean> {
+	try {
+		await fsp.access(chatgptAuthJsonPath());
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Returns true when either a DSH-managed token or the Codex auth file exists (row auto-discovery probe). */
 async function chatgptAuthExists(): Promise<boolean> {
+	const dsh = await readChatGPTDshStore();
+	if (dsh) return true;
 	try {
 		await fsp.access(chatgptAuthJsonPath());
 		return true;
@@ -239,6 +279,7 @@ interface ChatGPTTokenBundle {
 	refresh_token?: string;
 	id_token?: string;
 	account_id?: string;
+	plan_type?: string;
 	/** epoch ms when the access token expires (if known). */
 	expires_at_ms?: number;
 }
@@ -276,6 +317,67 @@ async function readChatGPTAuthFile(): Promise<ChatGPTTokenBundle> {
 		account_id: typeof tokens.account_id === 'string' ? tokens.account_id : undefined,
 		expires_at_ms
 	};
+}
+
+/**
+ * Read the DSH-managed ChatGPT token store (written by the in-plugin
+ * device-code login). Shape: { source:'dsh', account_id?, plan_type?,
+ * tokens:{access_token,refresh_token,id_token,expires_at_ms} }.
+ * Returns null (not throws) when absent/unreadable so the caller can
+ * fall through to the Codex auth.json source.
+ */
+async function readChatGPTDshStore(): Promise<(ChatGPTTokenBundle & { source: 'dsh'; plan_type?: string }) | null> {
+	const file = chatgptDshStorePath();
+	let raw: string;
+	try {
+		raw = await fsp.readFile(file, 'utf8');
+	} catch {
+		return null;
+	}
+	let parsed: any;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	const t = parsed?.tokens;
+	if (!t || typeof t.access_token !== 'string' || t.access_token.length === 0) return null;
+	return {
+		source: 'dsh',
+		access_token: t.access_token,
+		refresh_token: typeof t.refresh_token === 'string' ? t.refresh_token : undefined,
+		id_token: typeof t.id_token === 'string' ? t.id_token : undefined,
+		account_id: typeof parsed.account_id === 'string' ? parsed.account_id : undefined,
+		plan_type: typeof parsed.plan_type === 'string' ? parsed.plan_type : undefined,
+		expires_at_ms: typeof t.expires_at_ms === 'number' ? t.expires_at_ms : undefined
+	};
+}
+
+/** Atomically persist a token bundle to the DSH-managed store (0600 perms). */
+async function writeChatGPTDshStore(bundle: ChatGPTTokenBundle & { plan_type?: string }): Promise<void> {
+	const file = chatgptDshStorePath();
+	await fsp.mkdir(path.dirname(file), { recursive: true });
+	const payload = JSON.stringify({
+		source: 'dsh',
+		account_id: bundle.account_id,
+		plan_type: bundle.plan_type,
+		tokens: {
+			access_token: bundle.access_token,
+			refresh_token: bundle.refresh_token,
+			id_token: bundle.id_token,
+			expires_at_ms: bundle.expires_at_ms
+		}
+	}, null, 2);
+	await fsp.writeFile(file, payload, { encoding: 'utf8', mode: 0o600 });
+}
+
+async function deleteChatGPTDshStore(): Promise<void> {
+	try {
+		await fsp.unlink(chatgptDshStorePath());
+	} catch {
+		// already absent
+	}
+	chatgptTokenCache = null;
 }
 
 /**
@@ -342,11 +444,182 @@ async function refreshChatGPTToken(refreshToken: string, timeoutMs: number): Pro
 	};
 }
 
+/** PKCE verifier (high-entropy random string) and S256 challenge. */
+function chatgptPkce(): { verifier: string; challenge: string } {
+	const verifier = crypto.randomBytes(48).toString('base64url');
+	const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+	return { verifier, challenge };
+}
+
 /**
- * Resolve a usable access token: cache hit while fresh, else reload from
- * auth.json (which Codex may have refreshed in the meantime), else refresh
- * via the OAuth endpoint using the stored refresh_token. Refreshed tokens
- * are cached in memory only.
+ * In-flight device-code login. The host drives the OAuth device-authorization
+ * flow: it requests a one-time user code, the UI shows it with the
+ * verification URL, and the host polls until the user authorizes (or it
+ * times out / is cancelled). `abort` is set when the user cancels so the
+ * polling loop terminates and the next start can replace it.
+ */
+let chatgptLogin: {
+	startedAt: number;
+	verificationUrl: string;
+	userCode: string;
+	intervalMs: number;
+	expiresAt: number;
+	abort: boolean;
+} | null = null;
+
+/** Step 1: request a one-time code from the device-authorization endpoint. */
+async function chatgptDeviceStart(timeoutMs: number): Promise<{ verificationUrl: string; userCode: string; intervalMs: number; expiresAt: number }> {
+	const res = await fetch(CHATGPT_USERCODE_URL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+		body: JSON.stringify({ client_id: CHATGPT_CLIENT_ID }),
+		signal: AbortSignal.timeout(timeoutMs)
+	});
+	const json: any = await res.json().catch(() => null);
+	if (!res.ok || json === null) {
+		throw new Error(`ChatGPT device code request failed: ${json?.error_description || json?.error || `HTTP ${res.status}`}`);
+	}
+	const userCode = json.user_code ?? json.usercode;
+	const deviceAuthId = json.device_auth_id;
+	if (typeof userCode !== 'string' || !userCode || typeof deviceAuthId !== 'string') {
+		throw new Error('ChatGPT device code response missing user_code / device_auth_id');
+	}
+	const intervalSec = Number(json.interval);
+	const intervalMs = Number.isFinite(intervalSec) && intervalSec > 0 ? intervalSec * 1000 : 5000;
+	// The one-time code expires in 15 minutes (per Codex's device flow).
+	const expiresAt = Date.now() + 15 * 60 * 1000;
+	chatgptLogin = {
+		startedAt: Date.now(),
+		verificationUrl: CHATGPT_DEVICE_VERIFY_URL,
+		userCode,
+		intervalMs,
+		expiresAt,
+		abort: false
+	};
+	void chatgptDevicePoll(deviceAuthId, userCode, intervalMs);
+	return { verificationUrl: CHATGPT_DEVICE_VERIFY_URL, userCode, intervalMs, expiresAt };
+}
+
+/**
+ * Step 2: poll the device token endpoint until the user authorizes. On
+ * success the response carries an authorization_code plus PKCE codes; we
+ * then exchange the code for tokens and persist them to the DSH store.
+ * Errors (pending/denied/expired) are swallowed here and surfaced to the
+ * UI via chatgptLoginStatus().
+ */
+async function chatgptDevicePoll(deviceAuthId: string, userCode: string, initialIntervalMs: number): Promise<void> {
+	const deadline = Date.now() + 15 * 60 * 1000;
+	let intervalMs = initialIntervalMs;
+	let lastError: string | undefined;
+	while (Date.now() < deadline) {
+		if (chatgptLogin?.abort || chatgptLogin?.userCode !== userCode) return;
+		await new Promise((r) => setTimeout(r, intervalMs));
+		if (chatgptLogin?.abort || chatgptLogin?.userCode !== userCode) return;
+		try {
+			const res = await fetch(CHATGPT_DEVICETOKEN_URL, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+				body: JSON.stringify({ device_auth_id: deviceAuthId, user_code: userCode }),
+				signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS)
+			});
+			const json: any = await res.json().catch(() => null);
+			if (!json) continue;
+			if (json.authorization_code) {
+				const verifier = typeof json.code_verifier === 'string' && json.code_verifier
+					? json.code_verifier
+					: chatgptPkce().verifier;
+				const tokens = await chatgptExchangeCode(String(json.authorization_code), verifier);
+				await writeChatGPTDshStore(tokens);
+				chatgptTokenCache = { bundle: tokens };
+				chatgptLogin = null;
+				return;
+			}
+			// authorization_pending / slow_down / access_denied / expired_token
+			lastError = json.error_description || json.error || lastError;
+			if (json.error === 'access_denied' || json.error === 'expired_token') break;
+			if (json.error === 'slow_down' && intervalMs < 15000) {
+				intervalMs = Math.min(15000, intervalMs + 5000);
+			}
+		} catch (e) {
+			lastError = String((e as Error)?.message || e);
+		}
+	}
+	chatgptLogin = null;
+	throw new Error(lastError ? `ChatGPT login failed: ${lastError}` : 'ChatGPT login timed out');
+}
+
+/** Step 3: exchange an authorization_code (with PKCE) for a token bundle. */
+async function chatgptExchangeCode(code: string, codeVerifier: string, timeoutMs = UPSTREAM_TIMEOUT_MS): Promise<ChatGPTTokenBundle> {
+	const body = new URLSearchParams({
+		grant_type: 'authorization_code',
+		code,
+		redirect_uri: CHATGPT_DEVICE_REDIRECT_URI,
+		client_id: CHATGPT_CLIENT_ID,
+		code_verifier: codeVerifier
+	}).toString();
+	const res = await fetch(CHATGPT_TOKEN_URL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body,
+		signal: AbortSignal.timeout(timeoutMs)
+	});
+	const json: any = await res.json().catch(() => null);
+	if (!res.ok || json === null) {
+		throw new Error(`ChatGPT token exchange failed: ${json?.error_description || json?.error || `HTTP ${res.status}`}`);
+	}
+	if (typeof json.access_token !== 'string' || json.access_token.length === 0) {
+		throw new Error('ChatGPT token exchange response missing access_token');
+	}
+	const expiresIn = Number(json.expires_in);
+	let account_id: string | undefined;
+	let plan_type: string | undefined;
+	if (typeof json.id_token === 'string') {
+		const claims = chatgptDecodeIdToken(json.id_token);
+		account_id = claims.account_id;
+		plan_type = claims.plan_type;
+	}
+	return {
+		access_token: json.access_token,
+		refresh_token: typeof json.refresh_token === 'string' ? json.refresh_token : undefined,
+		id_token: typeof json.id_token === 'string' ? json.id_token : undefined,
+		account_id,
+		plan_type,
+		expires_at_ms: Number.isFinite(expiresIn) && expiresIn > 0 ? Date.now() + expiresIn * 1000 : undefined
+	} as ChatGPTTokenBundle;
+}
+
+/** Decode (without verifying) the id_token JWT payload for account/plan hints. */
+function chatgptDecodeIdToken(idToken: string): { account_id?: string; plan_type?: string } {
+	try {
+		const part = idToken.split('.')[1];
+		if (!part) return {};
+		const json = JSON.parse(Buffer.from(part.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'));
+		const ns = json?.['https://api.openai.com/auth'];
+		return {
+			account_id: typeof json?.account_id === 'string' ? json.account_id : (typeof ns?.user_id === 'string' ? ns.user_id : undefined),
+			plan_type: typeof json?.plan_type === 'string' ? json.plan_type : (typeof ns?.plan_type === 'string' ? ns.plan_type : undefined)
+		};
+	} catch {
+		return {};
+	}
+}
+
+/** Snapshot of the current in-flight login for the settings UI to render. */
+function chatgptLoginStatus(): { active: boolean; verificationUrl?: string; userCode?: string; expiresAt?: number } {
+	if (!chatgptLogin || chatgptLogin.abort) return { active: false };
+	return {
+		active: true,
+		verificationUrl: chatgptLogin.verificationUrl,
+		userCode: chatgptLogin.userCode,
+		expiresAt: chatgptLogin.expiresAt
+	};
+}
+
+/**
+ * Resolve a usable access token. Order:
+ *   1. in-memory cache while fresh
+ *   2. DSH-managed store (device-code login) — refreshed and written back
+ *   3. ~/.codex/auth.json (Codex CLI login) — refreshed in memory only
  */
 async function resolveChatGPTToken(timeoutMs: number): Promise<{ accessToken: string; accountId?: string }> {
 	const now = Date.now();
@@ -354,14 +627,29 @@ async function resolveChatGPTToken(timeoutMs: number): Promise<{ accessToken: st
 	if (cached && cached.access_token && (!cached.expires_at_ms || cached.expires_at_ms - now > 30_000)) {
 		return { accessToken: cached.access_token, accountId: cached.account_id };
 	}
+	// Source 1: DSH-managed device login (preferred).
+	const dsh = await readChatGPTDshStore();
+	if (dsh && dsh.access_token) {
+		if (!dsh.expires_at_ms || dsh.expires_at_ms - now > 30_000) {
+			chatgptTokenCache = { bundle: dsh };
+			return { accessToken: dsh.access_token, accountId: dsh.account_id };
+		}
+		if (dsh.refresh_token) {
+			const refreshed = await refreshChatGPTToken(dsh.refresh_token, timeoutMs);
+			if (!refreshed.account_id) refreshed.account_id = dsh.account_id;
+			await writeChatGPTDshStore(refreshed).catch(() => {});
+			chatgptTokenCache = { bundle: refreshed };
+			return { accessToken: refreshed.access_token, accountId: refreshed.account_id };
+		}
+	}
+	// Source 2: Codex CLI auth.json fallback.
 	const fromDisk = await readChatGPTAuthFile();
 	if (!fromDisk.expires_at_ms || fromDisk.expires_at_ms - now > 30_000) {
 		chatgptTokenCache = { bundle: fromDisk };
 		return { accessToken: fromDisk.access_token, accountId: fromDisk.account_id };
 	}
-	// Disk token is expired/near-expiry — refresh.
 	if (!fromDisk.refresh_token) {
-		throw new Error('ChatGPT: access token expired and auth.json has no refresh_token — run "codex login" again');
+		throw new Error('ChatGPT: access token expired and no refresh_token — log in again');
 	}
 	const refreshed = await refreshChatGPTToken(fromDisk.refresh_token, timeoutMs);
 	if (!refreshed.account_id) refreshed.account_id = fromDisk.account_id;
@@ -1323,6 +1611,38 @@ export function apply(ctx, config: Record<string, any> = {}) {
 
 	ctx.connection.rpc.handle(RPC_CHANNEL, async (endpoint, payload, _signal) => {
 		try {
+			// ── ChatGPT subscription auth (device-code login) ──────
+			// These endpoints drive the in-plugin device-authorization
+			// flow so users without Codex CLI can still log in. No
+			// secrets leave the host.
+			if (endpoint === 'chatgpt-auth-status') {
+				const dsh = await readChatGPTDshStore();
+				return {
+					ok: true,
+					value: {
+						loggedIn: !!(dsh?.access_token) || await chatgptAuthExists(),
+						source: dsh ? 'dsh' : (await codexAuthFileExists() ? 'codex' : null),
+						account_id: dsh?.account_id,
+						plan_type: dsh?.plan_type,
+						login: chatgptLoginStatus()
+					}
+				};
+			}
+			if (endpoint === 'chatgpt-login-start') {
+				// Cancel any in-flight login, then start a fresh one.
+				if (chatgptLogin) chatgptLogin.abort = true;
+				const info = await chatgptDeviceStart(UPSTREAM_TIMEOUT_MS);
+				return { ok: true, value: info };
+			}
+			if (endpoint === 'chatgpt-login-cancel') {
+				if (chatgptLogin) chatgptLogin.abort = true;
+				chatgptLogin = null;
+				return { ok: true, value: { cancelled: true } };
+			}
+			if (endpoint === 'chatgpt-logout') {
+				await deleteChatGPTDshStore();
+				return { ok: true, value: { loggedOut: true } };
+			}
 			const rows = await resolveRows(ctx, {
 				auto: raw.auto !== false,
 				hide: Array.isArray(raw.hide) ? raw.hide : [],


### PR DESCRIPTION
## 改动概述

为右下角配额面板新增 **ChatGPT 订阅（Plus / Pro）用量展示**，并提供**两种登录方式**：

1. **插件内设备码登录（推荐，无需安装 Codex CLI）**——在面板设置里点「登录 ChatGPT」，浏览器走 OAuth 设备码（device-code）授权，令牌由插件自行存储与刷新；
2. **复用 Codex CLI 登录**——已运行过 `codex login` 的用户，插件自动读取 `~/.codex/auth.json`。

登录后调用 Codex 同款的内部用量端点，把套餐的**周窗口**（以及 Pro 的 **5 小时窗口**）已用百分比显示在面板上。

---

> 另外，我注意到插件商店上的版本还是 0.8。我们此版本更新后，是否尝试提交插件 PR 到插件商店，以便更新版本？如果可以，我可以帮忙尝试更新版本。

---

## 背景

ChatGPT 订阅是套餐计费，不是 API 计费，OpenAI 没有为 Plus/Pro 提供公开的「剩余额度」接口。但官方开源的 Codex CLI 会向一个内部端点查询当前套餐的限速窗口用量（用于 CLI 的 `/status` 和 5 小时/周配额）。本 PR 复用同一条已验证可用的链路：

```
GET https://chatgpt.com/backend-api/wham/usage
Authorization: Bearer <ChatGPT OAuth access_token>
ChatGPT-Account-Id: <account_id>
```

我用自己的 Plus 账号实测返回正常（`plan_type: plus`、`primary_window.used_percent`、`reset_at` 等字段齐全）。Pro 账号的 `secondary_window` 映射为 5 小时窗口（字段语义参考 CodexBar / Jittor 的调研，并与 openai/codex 的 rate-limit 解析一致）。

> ⚠️ **实验性（experimental）**：该用量端点是 Codex CLI 内部使用的未公开 API，响应字段可能随官方调整而变化。代码注释、README 与 format 表均已标注「实验性」。插件只做只读查询。

## 两种登录方式

### 方式 A：插件内设备码登录（device-code flow）

完全在插件内完成，不依赖 Codex CLI 安装：

1. 宿主向 `POST https://auth.openai.com/api/accounts/deviceauth/usercode`（`client_id` 用 Codex 的 `app_EMoamEEZ73f0CkXaXp7hrann`）请求一次性 `user_code` + `device_auth_id`；
2. 客户端设置面板显示验证码与链接 `https://auth.openai.com/codex/device`，用户在浏览器登录授权；
3. 宿主按返回的 `interval` 轮询 `POST .../deviceauth/token`，拿到 `authorization_code`（+ PKCE verifier）；
4. 宿主用授权码向 `https://auth.openai.com/oauth/token`（`grant_type=authorization_code` + `code_verifier`）换取 `access_token` / `refresh_token` / `id_token`；
5. 从 `id_token` 解析 `account_id` / `plan_type`，令牌写入 `$DSH_HOME/dsh-quota-panel/chatgpt-auth.json`（0600 权限）；
6. access token 过期时用 refresh_token 自动刷新并回写；支持「退出登录」删除本地令牌。

登录过程中客户端每 2.5 秒查一次 `chatgpt-auth-status`，授权成功后自动刷新出行数据，无需重启。

### 方式 B：复用 Codex CLI 的 auth.json

检测到 `~/.codex/auth.json`（或 `$CODEX_HOME/auth.json`）时自动上板。此路径遵循 CodexBar 文档确立的**所有权边界**：刷新后的令牌只留在插件进程内存，**绝不回写** `auth.json`（该文件归 Codex CLI 所有）。

**解析顺序**：内存缓存 → DSH 插件内登录令牌（优先，并会刷新回写）→ Codex auth.json（刷新仅存内存）。两者皆无时 ChatGPT 行不显示。

## 实现细节

### 宿主侧（`src/index.ts`）

- 新增 OAuth 设备码流程：`chatgptDeviceStart` / `chatgptDevicePoll` / `chatgptExchangeCode` / `chatgptPkce` / `chatgptDecodeIdToken`；
- DSH 令牌存储：`readChatGPTDshStore` / `writeChatGPTDshStore` / `deleteChatGPTDshStore`，目录 `$DSH_HOME/dsh-quota-panel/`；
- `resolveChatGPTToken` 改为双源解析（DSH store → auth.json），均带过期前 30s 刷新；
- 新增 loopback RPC 端点（均在宿主侧完成，密钥不进浏览器）：
  - `chatgpt-login-start`：发起设备码登录，返回 `{ verificationUrl, userCode, expiresAt }`；
  - `chatgpt-auth-status`：返回 `{ loggedIn, source: 'dsh'|'codex', account_id, plan_type, login }`；
  - `chatgpt-login-cancel`：取消进行中的登录；
  - `chatgpt-logout`：删除 DSH 存储的令牌；
- `chatgptAuthExists` 自动发现探测改为「DSH store 或 auth.json 任一存在即上板」；
- 401 时清缓存强制刷新一次后重试。

### 客户端（`src/client.ts` / `lib/client.js`）

设置面板最上方新增 **ChatGPT 账号**区块：

- 未登录：显示说明 +「登录 ChatGPT」按钮；
- 登录中：显示授权链接、大号一次性验证码、「复制」按钮、「等待授权中…」、「取消」；
- 已登录：显示来源（插件内登录 / Codex CLI）与套餐，提供「退出登录」（仅删除插件令牌，不影响 Codex CLI 的 auth.json）；
- 新增 i18n 文案（zh + en）与极简样式（验证码、链接）。

usage 行的百分比/重置时间渲染完全复用现有通用 usage 视图，客户端无额外数据路径改动。

### 文档

- `README.md` / `README.zh.md`：「ChatGPT 订阅接入」一节改写为**方式 A / 方式 B** 两套步骤；目录表的凭据列改为「插件内登录 或 `~/.codex/auth.json`」；
- format 表保留 `chatgpt-subscription` 行。

### 测试（`scripts/test-page-script.mjs`）

新增/保留 9 个宿主侧测试，全部通过：

- auth.json 存在时自动发现；specs 不泄漏令牌/路径/endpoint；
- Plus 响应 → weekly 窗口；Pro 响应 → weekly + 5h；
- 无 auth.json 时隐藏；
- **仅有 DSH store、无 Codex auth.json 时也能发现并上报 `source=dsh` + plan**；
- `chatgpt-auth-status` 正确报告来源与套餐；
- `chatgpt-logout` 清除 DSH store 后状态变为未登录；
- 无登录进行中时 `chatgpt-login-cancel` 安全幂等。

并在测试顶部把 `CODEX_HOME` 默认指向空临时目录，新测试用独立的临时 `DSH_HOME`，保证测试在任何机器上都不会误读真实凭据。

```
npm run build && npm test  →  All dual-face checks passed.
```

另已用真实账号联调：`chatgpt-login-start` 成功从 OpenAI 取得一次性验证码与授权链接。

## 安全说明

- 令牌全部留宿主侧，`rowSpec()` 只下发展示字段；浏览器永远拿不到 access/refresh token；
- DSH 存储文件权限 0600；
- 设备码流程与 Codex CLI 同一 `client_id`、同一套 OAuth 端点；不收集、不上传任何凭据到第三方；
- 「退出登录」只删除插件自己写入的 DSH 文件，不会触碰用户的 Codex CLI 配置。

## 不在本 PR 范围内

- **Business / Enterprise 的 Analytics API**：那是聚合报表接口，不是个人实时套餐配额，语义不同，未纳入；
- **该供应商的按行 HTTP 代理**：现有代理引擎只支持 GET + Bearer，可按需要再扩展。

## Reviewer 配置参考

- 不想登录、也没装 Codex CLI 的用户：什么都不会多出来（行被隐藏）；
- 装了 Codex CLI 的用户：重启后直接看到行；
- 不想装 Codex CLI 的用户：打开面板设置 →「ChatGPT 账号」→「登录 ChatGPT」，浏览器授权即可；
- 想手动隐藏：`config.hide: [chatgpt]`。

## 致谢

用量端点与设备码流程字段参考了以下开源项目：

- [steipete/CodexBar 的 Codex OAuth 文档](https://github.com/steipete/CodexBar/blob/main/docs/codex-oauth.md)；
- 官方 [openai/codex](https://github.com/openai/codex)（`codex-rs/login/src/device_code_auth.rs`、`server.rs` 的 device-code 与 PKCE 换 token 实现）；
- Jittor provider telemetry research（`/backend-api/wham/usage` 字段与 primary/secondary 窗口语义）。