### PR TITLE
feat: show weekly reset time inline on weekly-only usage rows

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -349,10 +349,18 @@ window.fetch = function (url) {
     var labels = spec.windowLabels || { rolling: '滚', weekly: '周', monthly: '月' };
     var fmtWin = function (label, v) { return label + ' ' + (v === null ? '—' : v + '%'); };
 
-    // weekly absent -> dropped; search lane unknown -> -%
-    var textSegs = [fmtWin(labels.rolling, rp)];
-    if (wp !== null) textSegs.push(fmtWin(labels.weekly, wp));
-    textSegs.push(labels.monthly + ' ' + (mp === null ? '-%' : mp + '%'));
+    // weekly-only plans (ChatGPT Plus / Codex) drop empty 滚/月 noise and
+    // surface the weekly reset time inline.
+    var weeklyOnly = rp === null && wp !== null && mp === null;
+    var textSegs;
+    if (weeklyOnly) {
+      textSegs = [fmtWin(labels.weekly, wp)];
+      if (u.weekly && u.weekly.resetsAt) textSegs.push('下次重置 ' + fmtReset(u.weekly.resetsAt));
+    } else {
+      textSegs = [fmtWin(labels.rolling, rp)];
+      if (wp !== null) textSegs.push(fmtWin(labels.weekly, wp));
+      textSegs.push(labels.monthly + ' ' + (mp === null ? '-%' : mp + '%'));
+    }
     view.usage.textContent = textSegs.join(' · ');
     view.progress.style.width = Math.min(Math.max(high, 0), 100) + '%';
     view.caption.textContent = '当前已使用 ' + high + '%';

--- a/lib/client.js
+++ b/lib/client.js
@@ -349,10 +349,24 @@ window.__ModuleLoader__.load({
                 var titleLine = function (label, v, win) {
                     return label + ": " + (v === null ? t("noWinData") : v + "% · " + t("nextReset", { time: fmtNextReset(t, win && win.resetsAt) }));
                 };
-                var textSegs = [fmtWin(labels.rolling, rp)];
-                if (wp !== null)
-                    textSegs.push(fmtWin(labels.weekly, wp));
-                textSegs.push(labels.monthly + " " + (mp === null ? "-%" : mp + "%"));
+                // Weekly-only plans (ChatGPT Plus / Codex, Kimi weekly) have no
+                // rolling or monthly window. Drop the empty 滚 / 月 noise and
+                // surface the weekly reset time inline — it otherwise lives
+                // only in the hover title.
+                var weeklyOnly = rp === null && wp !== null && mp === null;
+                var textSegs;
+                if (weeklyOnly) {
+                    textSegs = [fmtWin(labels.weekly, wp)];
+                    if (w.weekly && w.weekly.resetsAt) {
+                        textSegs.push(t("nextReset", { time: fmtNextReset(t, w.weekly.resetsAt) }));
+                    }
+                }
+                else {
+                    textSegs = [fmtWin(labels.rolling, rp)];
+                    if (wp !== null)
+                        textSegs.push(fmtWin(labels.weekly, wp));
+                    textSegs.push(labels.monthly + " " + (mp === null ? "-%" : mp + "%"));
+                }
                 var titleLines = [titleLine(labels.rolling, rp, w.rolling)];
                 if (wp !== null)
                     titleLines.push(titleLine(labels.weekly, wp, w.weekly));

--- a/scripts/test-page-script.mjs
+++ b/scripts/test-page-script.mjs
@@ -849,6 +849,10 @@ check('B: renderer returns element', element && typeof element.type === 'functio
 	check('B: capsule weekly on a plan without weekly falls back to highest', rowView(t2, { ...baseSpec, capsuleMode: 'weekly' }, noWeekly).summary === '30%');
 	const noRolling = { view: { kind: 'usage', windows: { weekly: { percent: 80, resetsAt: '2026-08-21T12:01:00.000Z' } } } };
 	check('B: capsule rolling on a plan without rolling falls back to highest', rowView(t2, { ...baseSpec, capsuleMode: 'rolling' }, noRolling).summary === '80%');
+	const tReset = (key, params) => (key === 'nextReset' ? `下次重置 ${params.time}` : key);
+	const weeklyOnly = rowView(tReset, { ...baseSpec, windowLabels: { weekly: '7天' } }, noRolling);
+	check('B: weekly-only usage text shows reset inline and drops empty 滚/月', weeklyOnly.usageText === '7天 80% · 下次重置 2026-08-21 20:01');
+	check('B: multi-window usage text keeps 滚/周/月 and no inline reset', modeView.auto.usageText === 'winRolling 1% · winWeekly 40% · winMonthly 1%');
 	check('B: capsule mode setting + dictionary keys shipped', clientSource.includes('capsuleMode') && clientSource.includes('settingsCapsule') && clientSource.includes('capsuleAuto') && clientSource.includes('capsuleRolling') && clientSource.includes('capsuleWeekly') && clientSource.includes('capsuleMax'));
 	// Layout fixes from issue #1: the capsule must clear the bottom status
 	// row, and the shell overlay layer must not sit UNDER body-mounted

--- a/scripts/test-page-script.mjs
+++ b/scripts/test-page-script.mjs
@@ -850,8 +850,16 @@ check('B: renderer returns element', element && typeof element.type === 'functio
 	const noRolling = { view: { kind: 'usage', windows: { weekly: { percent: 80, resetsAt: '2026-08-21T12:01:00.000Z' } } } };
 	check('B: capsule rolling on a plan without rolling falls back to highest', rowView(t2, { ...baseSpec, capsuleMode: 'rolling' }, noRolling).summary === '80%');
 	const tReset = (key, params) => (key === 'nextReset' ? `下次重置 ${params.time}` : key);
+	// fmtNextReset renders in the runner's LOCAL timezone, so the expected
+	// string must be computed with the same local-time formatting instead of
+	// a hardcoded literal (CI runs in UTC, dev machines may not).
+	const fmtLocalReset = (iso) => {
+		const d = new Date(iso);
+		const pad = (n) => (n < 10 ? '0' : '') + n;
+		return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate()) + ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
+	};
 	const weeklyOnly = rowView(tReset, { ...baseSpec, windowLabels: { weekly: '7天' } }, noRolling);
-	check('B: weekly-only usage text shows reset inline and drops empty 滚/月', weeklyOnly.usageText === '7天 80% · 下次重置 2026-08-21 20:01');
+	check('B: weekly-only usage text shows reset inline and drops empty 滚/月', weeklyOnly.usageText === '7天 80% · 下次重置 ' + fmtLocalReset('2026-08-21T12:01:00.000Z'));
 	check('B: multi-window usage text keeps 滚/周/月 and no inline reset', modeView.auto.usageText === 'winRolling 1% · winWeekly 40% · winMonthly 1%');
 	check('B: capsule mode setting + dictionary keys shipped', clientSource.includes('capsuleMode') && clientSource.includes('settingsCapsule') && clientSource.includes('capsuleAuto') && clientSource.includes('capsuleRolling') && clientSource.includes('capsuleWeekly') && clientSource.includes('capsuleMax'));
 	// Layout fixes from issue #1: the capsule must clear the bottom status

--- a/src/client.ts
+++ b/src/client.ts
@@ -344,9 +344,22 @@
 				var titleLine = function (label, v, win) {
 					return label + ": " + (v === null ? t("noWinData") : v + "% · " + t("nextReset", { time: fmtNextReset(t, win && win.resetsAt) }));
 				};
-				var textSegs = [fmtWin(labels.rolling, rp)];
-				if (wp !== null) textSegs.push(fmtWin(labels.weekly, wp));
-				textSegs.push(labels.monthly + " " + (mp === null ? "-%" : mp + "%"));
+				// Weekly-only plans (ChatGPT Plus / Codex, Kimi weekly) have no
+				// rolling or monthly window. Drop the empty 滚 / 月 noise and
+				// surface the weekly reset time inline — it otherwise lives
+				// only in the hover title.
+				var weeklyOnly = rp === null && wp !== null && mp === null;
+				var textSegs;
+				if (weeklyOnly) {
+					textSegs = [fmtWin(labels.weekly, wp)];
+					if (w.weekly && w.weekly.resetsAt) {
+						textSegs.push(t("nextReset", { time: fmtNextReset(t, w.weekly.resetsAt) }));
+					}
+				} else {
+					textSegs = [fmtWin(labels.rolling, rp)];
+					if (wp !== null) textSegs.push(fmtWin(labels.weekly, wp));
+					textSegs.push(labels.monthly + " " + (mp === null ? "-%" : mp + "%"));
+				}
 				var titleLines = [titleLine(labels.rolling, rp, w.rolling)];
 				if (wp !== null) titleLines.push(titleLine(labels.weekly, wp, w.weekly));
 				titleLines.push(titleLine(labels.monthly, mp, w.monthly));


### PR DESCRIPTION
## Summary

Weekly-only usage rows (a weekly window with no rolling or monthly data) currently render empty `滚` / `月` segments and keep the reset time in the hover title only.

This change is display-only:

- if a row has only `weekly`, show `周 58% · 下次重置 2026-08-27 12:35` (localized via the existing `nextReset` key)
- drop the unused rolling / monthly noise for that case
- leave multi-window rows (MiniMax 5h + month, etc.) unchanged

No new provider, endpoint, format, or auth path.

## Test plan

- [x] `npm run check` (build + dual-face tests)
- [x] added checks:
  - weekly-only usage text shows the reset inline and drops empty 滚/月
  - multi-window usage text stays `滚 / 周 / 月` with no inline reset