### PR TITLE
火山方舟 Agent Plan / Coding Plan 拆分为两个独立供应商行同时显示

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,14 @@ After restart, check the panel:
   pay-as-you-go accounts; the two rows report independently — hide the
   unsubscribed one from the ⚙ settings panel).
 
+> **Migration (from ≤ 0.9.1-rc.3, if you pinned the old row):** the single
+> catalog row id `volcengine` and the format id `volcengine-usage` were
+> replaced by `volcengine-agent` (`volcengine-agent-usage`) and
+> `volcengine-coding` (`volcengine-coding-usage`). Auto-discovered setups need
+> no changes; a hand-written `catalog:` override or `providers:` entry that
+> still references the old ids makes the plugin refuse to load with a
+> validation error listing the valid ids — update it to the two new ids.
+
 > Security note: an AK/SK pair can read all Ark usage data for the account.
 > Redact it before pasting into chats, tickets, or screenshots, and rotate it
 > from the [key management page](https://console.volcengine.com/iam/keymanage)
@@ -596,14 +604,17 @@ This plugin builds on community work — thanks to:
 
 ## Changelog
 
-- **Unreleased** — Volcengine Ark Agent Plan and Coding Plan are now **shown as
+- **v0.9.1-rc.4** — Volcengine Ark Agent Plan and Coding Plan are now **shown as
   two rows at once** (previously a single row queried Agent Plan first and fell
   back to Coding Plan). The two subscriptions render as two independent
   providers sharing the same AK/SK pair: the Agent row (`volcengine-agent`,
   `GetAFPUsage`, 5h/weekly/monthly) and the Coding row (`volcengine-coding`,
   `GetCodingPlanUsage`, session/weekly/monthly) each query only their own API
   with no cross-fallback; a plan the account has not subscribed to reports its
-  own "not subscribed" message on that row.
+  own "not subscribed" message on that row. The Coding row's hover title labels
+  its rolling window `session:` (it is a session limit, not a 5h window), and a
+  migration note for the replaced row/format ids (`volcengine` /
+  `volcengine-usage`) was added to the Volcengine troubleshooting section.
 - **v0.8.1-rc.6** — layout fixes from issue #1, reworked: the panel is now
   **draggable** — grab the collapsed capsule or the expanded card header and
   move it anywhere (pointer capture, 5px move threshold so click-to-expand

--- a/README.md
+++ b/README.md
@@ -215,11 +215,11 @@ Explicit `providers` fields:
 | `id` | row id (RPC rows align by id), `^[a-z0-9-]+$` | required |
 | `label` | provider name shown on the card | required |
 | `credential` | credential reference (`$DSH_HOME/.credentials.yaml` or environment) | required |
-| `secretCredential` | second credential reference (Volcengine `volcengine-usage`: the SK) | — |
+| `secretCredential` | second credential reference (Volcengine `volcengine-agent-usage` / `volcengine-coding-usage`: the SK) | — |
 | `endpoint` | quota JSON endpoint; base URL for `openai-billing` | required |
 | `format` | row adapter (see table below) | `deepseek-balance` |
 | `proxy` | a proxy name defined in `proxies`; absent = direct | — |
-| `region` | (`volcengine-usage`) Volcengine OpenAPI region | `cn-beijing` |
+| `region` | (`volcengine-agent-usage` / `volcengine-coding-usage`) Volcengine OpenAPI region | `cn-beijing` |
 | `currency` | (balance rows) currency symbol, overrides the format default | format default |
 | `balanceTiers` | (balance rows) `{critical, warn, healthy}` | `{10, 20, 50}` |
 | `lowBalance` | legacy alias for `balanceTiers.warn` | — |
@@ -244,9 +244,15 @@ Explicit `providers` fields:
 | Z.AI GLM Coding | `ZAI_API_KEY` | `api.z.ai/api/monitor/usage/quota/limit` | coding-plan windows (5h tokens / weekly / searches) |
 | Kimi Coding | `KIMI_API_KEY` | `api.kimi.com/coding/v1/usages` | usage % (5h rate limit + weekly request pool) |
 | OpenCode Go | `OPENCODE_GO_API_KEY` | `opencode.ai/zen/go/v1/usage` | three-window usage % |
-| Volcengine Ark (火山方舟) | `VOLC_ACCESS_KEY` + `VOLC_SECRET_KEY` | `open.volcengineapi.com` (OpenAPI, signed) | usage % (Agent Plan 5h/weekly/monthly; falls back to Coding Plan) |
+| Volcengine Ark Agent Plan | `VOLC_ACCESS_KEY` + `VOLC_SECRET_KEY` | `open.volcengineapi.com` (OpenAPI, signed) | usage % (5h / weekly / monthly, `GetAFPUsage`) |
+| Volcengine Ark Coding Plan | `VOLC_ACCESS_KEY` + `VOLC_SECRET_KEY` | `open.volcengineapi.com` (OpenAPI, signed) | usage % (session / weekly / monthly, `GetCodingPlanUsage`) |
 
-> Volcengine Ark authenticates with an **AccessKey ID / SecretAccessKey pair** using
+> Volcengine Ark has **two separate subscriptions — Agent Plan and Coding Plan** —
+> shown as **two independent rows** (like two providers) that share the same
+> AK/SK pair. Each row queries only its own plan's API and never falls back to
+> the other, so a plan the account has not subscribed to shows a "not
+> subscribed" message on that row instead of the other plan's numbers.
+> Volcengine authenticates with an **AccessKey ID / SecretAccessKey pair** using
 > HMAC-SHA256 request signing — not a Bearer token. The inference `ARK_API_KEY`
 > (shaped `ark-...`) cannot query usage; only the AK/SK pair has OpenAPI
 > permission. Full setup is in the next section.
@@ -291,22 +297,26 @@ VOLC_SECRET_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 You can also use the `VOLC_ACCESS_KEY` / `VOLC_SECRET_KEY` environment
 variables (DSH's credential resolver falls back to the environment). Restart
-`dsh web`; the "Volcengine Ark" row appears in the bottom-right panel
-automatically — no `providers:` block required.
+`dsh web`; the "Volcengine Agent" and "Volcengine Coding" rows appear in the
+bottom-right panel automatically (whichever plan the account subscribes to
+shows data; both rows share the same AK/SK pair) — no `providers:` block required.
 
 **Verifying permissions**
 
 After restart, check the panel:
 
-- Three percentages (5h / weekly / monthly) render → AK/SK and
-  `ArkReadOnlyAccess` are both working;
+- The Agent row shows three percentages (5h / weekly / monthly) and the Coding
+  row shows three (session / weekly / monthly) → AK/SK and `ArkReadOnlyAccess`
+  are both working (if only one plan is subscribed, the other row shows a
+  "not subscribed" message);
 - `volcengine SignatureDoesNotMatch: ...` → the SK was copied wrong (watch the
   trailing `=`);
 - `volcengine AccessDenied: ...` → the policy is not attached or the wrong
   source policy was selected;
-- `No active Agent Plan or Coding Plan subscription` → the signature worked
-  but the account has no Agent/Coding Plan subscription (typical for pay-as-you-go
-  accounts; hide the row from the ⚙ settings panel).
+- `No active Volcengine Ark Agent/Coding Plan subscription` → the signature
+  worked but the account has no subscription to that plan (typical for
+  pay-as-you-go accounts; the two rows report independently — hide the
+  unsubscribed one from the ⚙ settings panel).
 
 > Security note: an AK/SK pair can read all Ark usage data for the account.
 > Redact it before pasting into chats, tickets, or screenshots, and rotate it
@@ -406,7 +416,8 @@ recover.
 | `opencode-usage` | usage % | `{ usage: { rolling|weekly|monthly: { percent, resetsAt } } }` |
 | `zai-coding-quota` | usage % | `{ code: 200, data: { limits: [{ type: TOKENS_LIMIT \| TIME_LIMIT \| CREDIT_LIMIT, unit, number, percentage, currentValue, usage, remaining, nextResetTime }] } }` — semantic mapping (glm-plan-usage2, issue #2): TOKENS_LIMIT `unit=3` → 5h window, `unit=6` → weekly, TIME_LIMIT → MCP monthly lane; unknown units fall back to `nextResetTime` ordering; every window prefers the `percentage` field. Credit/resource-package plans (issue #7) return CREDIT_LIMIT rows instead of token windows: they map onto rolling/weekly by `nextResetTime` order, and the hover title tags them `[CREDIT_LIMIT left remaining/number]` |
 | `kimi-coding-usage` | usage % | `{ usage: { limit, used, remaining, resetTime }, limits: [{ window: { duration, timeUnit }, detail: { limit, used, remaining, resetTime } }] }` — 5h = the `duration=300` window, weekly = `duration=10080` (fallback: top-level usage); used = limit − remaining |
-| `volcengine-usage` | usage % | Dispatched inline in `fetchRow` (not through `adaptRow`): signs and calls the Volcengine Ark OpenAPI `GetAFPUsage`, then falls back to `GetCodingPlanUsage`. Agent Plan parses `Result.AFPFiveHour / AFPWeekly / AFPMonthly` (AFPDaily skipped per the console). Coding Plan parses `Result.QuotaUsage[].Level ∈ {session,weekly,monthly}` (percentages only). |
+| `volcengine-agent-usage` | usage % | Dispatched inline in `fetchRow` (not through `adaptRow`): signs and calls the Volcengine Ark OpenAPI `GetAFPUsage`, parsing `Result.AFPFiveHour / AFPWeekly / AFPMonthly` (Agent Plan 5h/weekly/monthly; AFPDaily skipped per the console). |
+| `volcengine-coding-usage` | usage % | Dispatched inline in `fetchRow` (not through `adaptRow`): signs and calls the Volcengine Ark OpenAPI `GetCodingPlanUsage`, parsing `Result.QuotaUsage[].Level ∈ {session,weekly,monthly}` (Coding Plan session/weekly/monthly, percentages only). Independent from the Agent row — no fallback between them. |
 | `chatgpt-subscription` | usage % | `{ plan_type, rate_limit: { primary_window: { used_percent, reset_at, limit_window_seconds }, secondary_window? } }` — read via the OAuth token in `~/.codex/auth.json` against Codex's internal usage endpoint; windows are classified by `limit_window_seconds` (18000s ≈ 5h → rolling, 604800s ≈ 7d → weekly), falling back to the typical positional layout (primary = 5h session, secondary = weekly pool). Experimental |
 
 ### Proxy (providers that cannot be reached directly)
@@ -585,6 +596,14 @@ This plugin builds on community work — thanks to:
 
 ## Changelog
 
+- **Unreleased** — Volcengine Ark Agent Plan and Coding Plan are now **shown as
+  two rows at once** (previously a single row queried Agent Plan first and fell
+  back to Coding Plan). The two subscriptions render as two independent
+  providers sharing the same AK/SK pair: the Agent row (`volcengine-agent`,
+  `GetAFPUsage`, 5h/weekly/monthly) and the Coding row (`volcengine-coding`,
+  `GetCodingPlanUsage`, session/weekly/monthly) each query only their own API
+  with no cross-fallback; a plan the account has not subscribed to reports its
+  own "not subscribed" message on that row.
 - **v0.8.1-rc.6** — layout fixes from issue #1, reworked: the panel is now
   **draggable** — grab the collapsed capsule or the expanded card header and
   move it anywhere (pointer capture, 5px move threshold so click-to-expand

--- a/README.zh.md
+++ b/README.zh.md
@@ -248,6 +248,13 @@ VOLC_SECRET_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 - 显示 `volcengine AccessDenied: ...` → 策略没挂上或挂错了来源；
 - 显示 `No active Volcengine Ark Agent/Coding Plan subscription` → 签名通过但该账号没有订阅对应套餐（按量付费账号就会这样；两行各自独立提示，可在 ⚙ 设置里隐藏未订阅的那一行）。
 
+> **迁移说明（≤ 0.9.1-rc.3，仅影响手动固定过旧行的用户）：** 原来的单一目录行 id
+> `volcengine` 与 format id `volcengine-usage` 已被替换为 `volcengine-agent`
+> （`volcengine-agent-usage`）与 `volcengine-coding`（`volcengine-coding-usage`）。
+> 走自动发现的用户无需任何改动；若你的配置里手写过引用旧 id 的 `catalog:` 覆盖或
+> `providers:` 条目，插件会校验失败并拒绝加载（错误信息会列出全部合法 id）——
+> 把旧 id 改成两个新 id 即可。
+
 > 安全建议：AK/SK 一旦泄露他人可以读你方舟账号的所有用量数据，贴到聊天/工单/截图前先打码；不再用时去 [密钥管理页](https://console.volcengine.com/iam/keymanage) 禁用并轮换。
 | ChatGPT 订阅（Plus/Pro） | 插件内登录 或 `~/.codex/auth.json`（无需 API Key） | `chatgpt.com/backend-api/wham/usage` | 周用量%（Pro 含 5h 窗口） |
 
@@ -489,7 +496,7 @@ manifest（浏览器侧自动进入 `__DSH_BOOT__` 模块图，`immediately: tru
 
 ## 更新日志
 
-- **未发布** —— 火山方舟 Agent Plan 与 Coding Plan **拆成两行同时显示**（此前是「先查 Agent Plan、无数据才回落 Coding Plan」的单行二选一）。两个套餐现在像两个独立供应商一样各自一行、共享同一对 AK/SK：Agent 行（`volcengine-agent`，`GetAFPUsage`，5h/周/月）与 Coding 行（`volcengine-coding`，`GetCodingPlanUsage`，会话/周/月）分别只查自己的接口、互不回落，未订阅的套餐显示独立的「未订阅」提示。
+- **v0.9.1-rc.4** —— 火山方舟 Agent Plan 与 Coding Plan **拆成两行同时显示**（此前是「先查 Agent Plan、无数据才回落 Coding Plan」的单行二选一）。两个套餐现在像两个独立供应商一样各自一行、共享同一对 AK/SK：Agent 行（`volcengine-agent`，`GetAFPUsage`，5h/周/月）与 Coding 行（`volcengine-coding`，`GetCodingPlanUsage`，会话/周/月）分别只查自己的接口、互不回落，未订阅的套餐显示独立的「未订阅」提示。Coding 行悬停标题的滚动窗口改标为 `session:`（会话限额而非 5h 窗口），并在火山排错段补充了旧行 id（`volcengine` / `volcengine-usage`）的迁移说明。
 - **v0.8.1-rc.6** —— issue #1 布局修复（重构版）：面板现在**可拖动**——抓住收起态
   胶囊或展开卡片头部即可拖到任意位置（指针捕获；5px 移动阈值，轻微晃动不影
   响点击展开；始终钳位在视口内，不会拖丢；位置与其他设置一并持久化到

--- a/README.zh.md
+++ b/README.zh.md
@@ -176,11 +176,11 @@ credential 引用名，UPPER_SNAKE）/ `secretRefs`（第二凭据引用，火�
 | `id` | 行标识（RPC 行按 id 对齐），`^[a-z0-9-]+$` | 必填 |
 | `label` | 卡片上的提供方名称 | 必填 |
 | `credential` | 凭据引用（`$DSH_HOME/.credentials.yaml` 或环境变量） | 必填 |
-| `secretCredential` | 第二凭据引用（火山方舟 `volcengine-usage` 需要：SK） | — |
+| `secretCredential` | 第二凭据引用（火山方舟 `volcengine-agent-usage` / `volcengine-coding-usage` 需要：SK） | — |
 | `endpoint` | 额度 JSON 接口；`openai-billing` 格式时为聚合站 base URL | 必填 |
 | `format` | 行适配器（见下表） | `deepseek-balance` |
 | `proxy` | `proxies` 中定义的代理名；缺省直连 | — |
-| `region` | （`volcengine-usage`）OpenAPI 区域，默认 `cn-beijing` | `cn-beijing` |
+| `region` | （`volcengine-agent-usage` / `volcengine-coding-usage`）OpenAPI 区域，默认 `cn-beijing` | `cn-beijing` |
 | `currency` | （余额型）币种符号，覆盖 format 默认值 | format 默认 |
 | `balanceTiers` | （余额型）`{critical, warn, healthy}` 分级阈值 | `{10, 20, 50}` |
 | `lowBalance` | 旧版别名，等价于 `balanceTiers.warn` | — |
@@ -205,9 +205,10 @@ credential 引用名，UPPER_SNAKE）/ `secretRefs`（第二凭据引用，火�
 | Z.AI GLM Coding | `ZAI_API_KEY` | `api.z.ai/api/monitor/usage/quota/limit` | 套餐窗口（5h tokens / 周 / MCP 月度） |
 | Kimi Coding | `KIMI_API_KEY` | `api.kimi.com/coding/v1/usages` | 用量%（5h 限频 + 周请求池） |
 | OpenCode Go | `OPENCODE_GO_API_KEY` | `opencode.ai/zen/go/v1/usage` | 三窗口用量% |
-| 火山方舟（Volcengine Ark） | `VOLC_ACCESS_KEY` + `VOLC_SECRET_KEY` | `open.volcengineapi.com`（OpenAPI 签名） | 用量%（Agent Plan 5h/周/月；无则回落 Coding Plan） |
+| 火山方舟 Agent Plan | `VOLC_ACCESS_KEY` + `VOLC_SECRET_KEY` | `open.volcengineapi.com`（OpenAPI 签名） | 用量%（5h / 周 / 月，`GetAFPUsage`） |
+| 火山方舟 Coding Plan | `VOLC_ACCESS_KEY` + `VOLC_SECRET_KEY` | `open.volcengineapi.com`（OpenAPI 签名） | 用量%（会话 / 周 / 月，`GetCodingPlanUsage`） |
 
-> 火山方舟使用**两组凭据**（AccessKey ID + SecretAccessKey）做 HMAC-SHA256 签名，不是 Bearer Token；推理用的 `ARK_API_KEY`（形如 `ark-...`）不能用于此查询，只有 AK/SK 有 OpenAPI 权限。完整接入步骤见下一节。
+> 火山方舟有 **Agent Plan 和 Coding Plan 两个相互独立的套餐**，插件把它们作为**两行**同时显示（就像两个供应商），共享同一对 AK/SK：每行只查询自己的套餐接口，互不回落——未订阅的那个套餐会显示一行「未订阅」提示，而不是显示另一个套餐的数字。火山方舟使用**两组凭据**（AccessKey ID + SecretAccessKey）做 HMAC-SHA256 签名，不是 Bearer Token；推理用的 `ARK_API_KEY`（形如 `ark-...`）不能用于此查询，只有 AK/SK 有 OpenAPI 权限。完整接入步骤见下一节。
 
 #### 火山方舟（Volcengine Ark）接入教程
 
@@ -236,16 +237,16 @@ VOLC_ACCESS_KEY: AKLTxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 VOLC_SECRET_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-或者用环境变量 `VOLC_ACCESS_KEY` / `VOLC_SECRET_KEY`（DSH 凭据解析支持环境变量回退）。重启 `dsh web` 后，右下角面板会自动出现「Volcengine Ark」行，无需在插件配置里加 `providers:`。
+或者用环境变量 `VOLC_ACCESS_KEY` / `VOLC_SECRET_KEY`（DSH 凭据解析支持环境变量回退）。重启 `dsh web` 后，右下角面板会自动出现「Volcengine Agent」和「Volcengine Coding」两行（订阅了哪个套餐，哪一行就有数据；两行共享同一对 AK/SK），无需在插件配置里加 `providers:`。
 
 **怎么验证权限是否正确**
 
 重启后看面板：
 
-- 出现 5h / 周 / 月三条百分比 → AK/SK 与 `ArkReadOnlyAccess` 都生效；
+- Agent 行出现 5h / 周 / 月三条百分比、Coding 行出现会话 / 周 / 月三条 → AK/SK 与 `ArkReadOnlyAccess` 都生效（只订阅了其中一个套餐时，另一个套餐那一行会显示「未订阅」提示）；
 - 显示 `volcengine SignatureDoesNotMatch: ...` → SK 复制错了（注意尾部的 `=`）；
 - 显示 `volcengine AccessDenied: ...` → 策略没挂上或挂错了来源；
-- 显示 `No active Agent Plan or Coding Plan subscription` → 签名通过但该账号没有订阅 Agent/Coding Plan（按量付费账号就会这样，面板上可以在 ⚙ 设置里隐藏这一行）。
+- 显示 `No active Volcengine Ark Agent/Coding Plan subscription` → 签名通过但该账号没有订阅对应套餐（按量付费账号就会这样；两行各自独立提示，可在 ⚙ 设置里隐藏未订阅的那一行）。
 
 > 安全建议：AK/SK 一旦泄露他人可以读你方舟账号的所有用量数据，贴到聊天/工单/截图前先打码；不再用时去 [密钥管理页](https://console.volcengine.com/iam/keymanage) 禁用并轮换。
 | ChatGPT 订阅（Plus/Pro） | 插件内登录 或 `~/.codex/auth.json`（无需 API Key） | `chatgpt.com/backend-api/wham/usage` | 周用量%（Pro 含 5h 窗口） |
@@ -330,7 +331,8 @@ ChatGPT OAuth 令牌调用 Codex 同款的内部用量端点，把 Plus/Pro 套�
 | `opencode-usage` | 用量% | `{ usage: { rolling|weekly|monthly: { percent, resetsAt } } }` |
 | `zai-coding-quota` | 用量% | `{ code: 200, data: { limits: [{ type: TOKENS_LIMIT \| TIME_LIMIT \| CREDIT_LIMIT, unit, number, percentage, currentValue, usage, remaining, nextResetTime }] } }` —— 语义映射（glm-plan-usage2，issue #2）：TOKENS_LIMIT `unit=3` → 5h 窗口、`unit=6` → 周、TIME_LIMIT → MCP 月度车道；未知 unit 回退按 `nextResetTime` 排序；各窗口百分比优先取 `percentage` 字段。积分/资源包套餐（issue #7）返回的是 CREDIT_LIMIT 行而非 token 窗口：按 `nextResetTime` 顺序映射到 滚动/周 泳道，悬停标题以 `[CREDIT_LIMIT left 剩余/包数]` 标注 |
 | `kimi-coding-usage` | 用量% | `{ usage: { limit, used, remaining, resetTime }, limits: [{ window: { duration, timeUnit }, detail: { limit, used, remaining, resetTime } }] }` —— 5h = `duration=300` 的窗口、周 = `duration=10080`（缺失时回退顶层 usage）；used = limit − remaining |
-| `volcengine-usage` | 用量% | 不走 `adaptRow`：`fetchRow` 内部以 AK/SK HMAC-SHA256 签名调用火山引擎 OpenAPI `GetAFPUsage` → `GetCodingPlanUsage`（回落），解析 `Result.AFPFiveHour/AFPWeekly/AFPMonthly`（Agent Plan，AFPDaily 跳过）或 `Result.QuotaUsage[].Level ∈ {session,weekly,monthly}`（Coding Plan，仅百分比） |
+| `volcengine-agent-usage` | 用量% | 不走 `adaptRow`：`fetchRow` 内部以 AK/SK HMAC-SHA256 签名调用火山引擎 OpenAPI `GetAFPUsage`，解析 `Result.AFPFiveHour/AFPWeekly/AFPMonthly`（Agent Plan 的 5h/周/月，AFPDaily 按控制台惯例跳过） |
+| `volcengine-coding-usage` | 用量% | 不走 `adaptRow`：`fetchRow` 内部以 AK/SK HMAC-SHA256 签名调用火山引擎 OpenAPI `GetCodingPlanUsage`，解析 `Result.QuotaUsage[].Level ∈ {session,weekly,monthly}`（Coding Plan 的会话/周/月，仅百分比）。与 Agent 行相互独立、互不回落 |
 | `chatgpt-subscription` | 用量% | `{ plan_type, rate_limit: { primary_window: { used_percent, reset_at, limit_window_seconds }, secondary_window? } }` —— 经 `~/.codex/auth.json` 的 OAuth 令牌读取 Codex 内部用量端点；按 `limit_window_seconds` 判别窗口（18000s≈5h → 滚动，604800s≈7天 → 周），字段缺失时按典型布局回退（primary = 5h 会话窗，secondary = 周池）。实验性接口 |
 
 ### 代理（部分供应商无法直连时）
@@ -487,6 +489,7 @@ manifest（浏览器侧自动进入 `__DSH_BOOT__` 模块图，`immediately: tru
 
 ## 更新日志
 
+- **未发布** —— 火山方舟 Agent Plan 与 Coding Plan **拆成两行同时显示**（此前是「先查 Agent Plan、无数据才回落 Coding Plan」的单行二选一）。两个套餐现在像两个独立供应商一样各自一行、共享同一对 AK/SK：Agent 行（`volcengine-agent`，`GetAFPUsage`，5h/周/月）与 Coding 行（`volcengine-coding`，`GetCodingPlanUsage`，会话/周/月）分别只查自己的接口、互不回落，未订阅的套餐显示独立的「未订阅」提示。
 - **v0.8.1-rc.6** —— issue #1 布局修复（重构版）：面板现在**可拖动**——抓住收起态
   胶囊或展开卡片头部即可拖到任意位置（指针捕获；5px 移动阈值，轻微晃动不影
   响点击展开；始终钳位在视口内，不会拖丢；位置与其他设置一并持久化到

--- a/lib/index.js
+++ b/lib/index.js
@@ -1605,7 +1605,7 @@ function parseVolcengineCodingPlan(result) {
     if (Object.keys(windows).length === 0)
         return null;
     const title = [
-        `5h: ${windows.rolling?.percent ?? '—'}%`,
+        `session: ${windows.rolling?.percent ?? '—'}%`,
         `weekly: ${windows.weekly?.percent ?? '—'}%`,
         `monthly: ${windows.monthly?.percent ?? '—'}%`
     ].join('\n');

--- a/lib/index.js
+++ b/lib/index.js
@@ -799,7 +799,8 @@ const FORMAT_META = {
     'opencode-usage': { kind: 'usage' },
     'zai-coding-quota': { kind: 'usage' },
     'kimi-coding-usage': { kind: 'usage' },
-    'volcengine-usage': { kind: 'usage' },
+    'volcengine-agent-usage': { kind: 'usage' },
+    'volcengine-coding-usage': { kind: 'usage' },
     'chatgpt-subscription': { kind: 'usage' }
 };
 /**
@@ -822,11 +823,17 @@ const CATALOG = [
     { id: 'zai', label: 'Z.AI GLM Coding', refs: ['ZAI_API_KEY'], endpoint: 'https://api.z.ai/api/monitor/usage/quota/limit', format: 'zai-coding-quota', windowLabels: { rolling: '5h', weekly: '周', monthly: '月' } },
     { id: 'kimi-coding', label: 'Kimi Coding', refs: ['KIMI_API_KEY'], endpoint: 'https://api.kimi.com/coding/v1/usages', format: 'kimi-coding-usage', windowLabels: { rolling: '5h', weekly: '周' } },
     { id: 'opencode-go', label: 'OpenCode Go', refs: ['OPENCODE_GO_API_KEY'], endpoint: 'https://opencode.ai/zen/go/v1/usage', format: 'opencode-usage' },
-    // Volcengine Ark (火山方舟): Agent Plan + Coding Plan usage via the
-    // OpenAPI control plane. Unlike every other catalog row this one
-    // authenticates with an AK/SK pair (signed, not Bearer) —
+    // Volcengine Ark (火山方舟) has two SEPARATE subscriptions, shown as two
+    // independent rows (like two providers) that share the same AK/SK pair.
+    // Unlike Bearer-key rows these authenticate with a signed AK/SK —
     // `secretRefs` is the second credential and fetchRow signs the request.
-    { id: 'volcengine', label: 'Volcengine Ark', refs: ['VOLC_ACCESS_KEY'], secretRefs: ['VOLC_SECRET_KEY'], endpoint: 'https://open.volcengineapi.com', format: 'volcengine-usage', windowLabels: { rolling: '5h', weekly: '周', monthly: '月' } },
+    //  • Agent Plan  -> GetAFPUsage      (5h rolling / weekly / monthly windows)
+    //  • Coding Plan -> GetCodingPlanUsage (session / weekly / monthly windows)
+    // Each row queries ONLY its own action; a plan the account has not
+    // subscribed to reports an inline "not subscribed" message instead of
+    // silently falling back to the other plan.
+    { id: 'volcengine-agent', label: 'Volcengine Agent', refs: ['VOLC_ACCESS_KEY'], secretRefs: ['VOLC_SECRET_KEY'], endpoint: 'https://open.volcengineapi.com', format: 'volcengine-agent-usage', windowLabels: { rolling: '5h', weekly: '周', monthly: '月' } },
+    { id: 'volcengine-coding', label: 'Volcengine Coding', refs: ['VOLC_ACCESS_KEY'], secretRefs: ['VOLC_SECRET_KEY'], endpoint: 'https://open.volcengineapi.com', format: 'volcengine-coding-usage', windowLabels: { rolling: '会话', weekly: '周', monthly: '月' } },
     // ChatGPT subscription (Plus/Pro/Business via Codex OAuth). Unlike every
     // other row this does NOT use ctx.credentials: tokens are read from
     // ~/.codex/auth.json (written by `codex login`) and refreshed host-side.
@@ -1104,13 +1111,16 @@ const FORMATS = {
         ].filter(Boolean).join('\n');
         return { kind: 'usage', windows, title };
     },
-    // `volcengine-usage` is not dispatched through adaptRow: fetchRow handles
-    // the two-step GetAFPUsage → GetCodingPlanUsage fallback inline because
-    // the Volcengine auth path (signed AK/SK, not Bearer) and response
-    // envelopes differ from every other provider. The adapter exists so the
-    // format is registered in FORMATS/FORMAT_META for config validation.
-    'volcengine-usage': () => {
-        throw new Error('volcengine-usage is handled inline by fetchRow');
+    // `volcengine-agent-usage` / `volcengine-coding-usage` are not dispatched
+    // through adaptRow: fetchRow handles each inline because the Volcengine
+    // auth path (signed AK/SK, not Bearer) and response envelopes differ from
+    // every other provider. Each adapter exists only so the format is
+    // registered in FORMATS/FORMAT_META for config validation.
+    'volcengine-agent-usage': () => {
+        throw new Error('volcengine-agent-usage is handled inline by fetchRow');
+    },
+    'volcengine-coding-usage': () => {
+        throw new Error('volcengine-coding-usage is handled inline by fetchRow');
     },
     // chatgpt-subscription is dispatched inline in fetchRow because it uses
     // an OAuth token from ~/.codex/auth.json (with refresh), not ctx.credentials.
@@ -1142,7 +1152,7 @@ export const Config = z.object({
             z.const('moonshot-balance'), z.const('minimax-remains'), z.const('stepfun-accounts'),
             z.const('xai-credits'), z.const('openai-billing'), z.const('zhipu-quota'),
             z.const('opencode-usage'), z.const('zai-coding-quota'), z.const('kimi-coding-usage'),
-            z.const('volcengine-usage'), z.const('chatgpt-subscription')
+            z.const('volcengine-agent-usage'), z.const('volcengine-coding-usage'), z.const('chatgpt-subscription')
         ]).default('deepseek-balance'),
         proxy: z.string(),
         currency: z.string(),
@@ -1517,8 +1527,9 @@ function volcEpochToIso(v) {
  * Parse a GetAFPUsage `Result` into rolling/weekly/monthly usage windows.
  * AFPDaily is intentionally skipped (hidden in the official console — its
  * quota is the legacy default, not an enforced limit). Quota<=0 marks an
- * unbound/unsubscribed window and is dropped, so an empty result means "no
- * active Agent Plan" and the caller falls through to Coding Plan.
+ * unbound/unsubscribed window and is dropped, so a null result means "no
+ * active Agent Plan" for the Agent row (it reports not-subscribed; the
+ * Coding Plan is a separate row queried independently, no fallback).
  */
 function parseVolcengineAFP(result) {
     const parseWin = (key) => {
@@ -1663,13 +1674,16 @@ async function fetchRow(ctx, provider, proxies, clientProxyUrl) {
         }
         // ── Volcengine Ark: AK/SK signed OpenAPI, not Bearer ──────
         //
-        // Calls GetAFPUsage first (Agent Plan); if no quota windows
-        // come back (signature OK but no subscription), falls through
-        // to GetCodingPlanUsage. Per-row errors are surfaced inline;
-        // auth failures carry the upstream code in the message.
-        if (provider.format === 'volcengine-usage') {
+        // Two independent subscription rows share the same AK/SK:
+        //   volcengine-agent  -> GetAFPUsage      (Agent Plan)
+        //   volcengine-coding -> GetCodingPlanUsage (Coding Plan)
+        // Each row queries ONLY its own action — no fallback between the
+        // two, so a plan the account has not subscribed to reports an
+        // inline "not subscribed" message rather than showing the other
+        // plan's numbers. Auth failures carry the upstream code.
+        if (provider.format === 'volcengine-agent-usage' || provider.format === 'volcengine-coding-usage') {
             if (!provider.secretCredential) {
-                return { id: provider.id, error: 'volcengine-usage requires both VOLC_ACCESS_KEY and VOLC_SECRET_KEY (only the AK was resolved)' };
+                return { id: provider.id, error: `${provider.format} requires both VOLC_ACCESS_KEY and VOLC_SECRET_KEY (only the AK was resolved)` };
             }
             const skHit = await ctx.credentials.resolve(provider.secretCredential);
             if (!skHit || typeof skHit.value !== 'string' || skHit.value.length === 0) {
@@ -1689,23 +1703,27 @@ async function fetchRow(ctx, provider, proxies, clientProxyUrl) {
                 if (m)
                     region = m[1];
             }
+            const isAgent = provider.format === 'volcengine-agent-usage';
             try {
-                const afpBody = await volcengineCall('GetAFPUsage', region, ak, sk, UPSTREAM_TIMEOUT_MS);
-                const afpResult = afpBody?.Result ?? afpBody;
-                const afpView = parseVolcengineAFP(afpResult);
-                if (afpView) {
-                    const plan = afpResult?.PlanType ? `Agent Plan ${afpResult.PlanType}` : 'Agent Plan';
-                    afpView.title = `plan: ${plan}\n` + afpView.title;
-                    return { id: provider.id, view: afpView };
+                if (isAgent) {
+                    const body = await volcengineCall('GetAFPUsage', region, ak, sk, UPSTREAM_TIMEOUT_MS);
+                    const result = body?.Result ?? body;
+                    const view = parseVolcengineAFP(result);
+                    if (view) {
+                        const plan = result?.PlanType ? `Agent Plan ${result.PlanType}` : 'Agent Plan';
+                        view.title = `plan: ${plan}\n` + view.title;
+                        return { id: provider.id, view };
+                    }
+                    return { id: provider.id, error: 'No active Volcengine Ark Agent Plan subscription (GetAFPUsage returned no quota windows)' };
                 }
-                const cpBody = await volcengineCall('GetCodingPlanUsage', region, ak, sk, UPSTREAM_TIMEOUT_MS);
-                const cpResult = cpBody?.Result ?? cpBody;
-                const cpView = parseVolcengineCodingPlan(cpResult);
-                if (cpView) {
-                    cpView.title = 'plan: Coding Plan\n' + cpView.title;
-                    return { id: provider.id, view: cpView };
+                const body = await volcengineCall('GetCodingPlanUsage', region, ak, sk, UPSTREAM_TIMEOUT_MS);
+                const result = body?.Result ?? body;
+                const view = parseVolcengineCodingPlan(result);
+                if (view) {
+                    view.title = 'plan: Coding Plan\n' + view.title;
+                    return { id: provider.id, view };
                 }
-                return { id: provider.id, error: 'No active Agent Plan or Coding Plan subscription' };
+                return { id: provider.id, error: 'No active Volcengine Ark Coding Plan subscription (GetCodingPlanUsage returned no quota windows)' };
             }
             catch (ve) {
                 return { id: provider.id, error: String((ve && ve.message) || ve) };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-quota-panel",
   "description": "Provider quota/balance widget for the dsh web surface: collapsed glanceable capsule expanding into a Harness-native card with a settings panel (provider visibility / refresh interval / warn thresholds), fed by a loopback Connection RPC channel whose host half proxies each provider with credentials that never reach the browser.",
-  "version": "0.9.1-rc.3",
+  "version": "0.9.1-rc.4",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/scripts/test-page-script.mjs
+++ b/scripts/test-page-script.mjs
@@ -251,10 +251,15 @@ check('A: zhipu quota percentage fallback', (() => {
 })());
 
 // ---------- A2c: Volcengine Ark (AK/SK signed OpenAPI) ----------
-// Volcengine requires BOTH refs to resolve before the row is discovered;
-// fetchRow calls GetAFPUsage first and falls back to GetCodingPlanUsage.
-// The signed POST goes through globalThis.fetch with the query in the URL,
-// so the test harness can stub by URL substring without caring about headers.
+// Volcengine ships TWO separate subscriptions shown as two independent rows
+// that share the same AK/SK pair:
+//   volcengine-agent  -> GetAFPUsage       (Agent Plan: 5h/weekly/monthly)
+//   volcengine-coding -> GetCodingPlanUsage (Coding Plan: session/weekly/monthly)
+// Each row queries ONLY its own action — no fallback between the two, so a
+// plan the account has not subscribed to reports an inline "not subscribed"
+// message rather than showing the other plan's numbers. The signed POST goes
+// through globalThis.fetch with the query in the URL, so the harness stubs by
+// URL substring without caring about headers.
 let veHandler;
 let veCalls = [];
 let veInits = [];
@@ -265,6 +270,7 @@ const veJson = (obj, ok = true, status = 200) => ({
 	status,
 	arrayBuffer: async () => new TextEncoder().encode(JSON.stringify(obj)).buffer
 });
+// Both plans subscribed: GetAFPUsage returns Agent Plan windows, GetCodingPlanUsage returns Coding Plan.
 globalThis.fetch = async (url, init) => {
 	veCalls.push(String(url));
 	veInits.push(init);
@@ -279,39 +285,69 @@ globalThis.fetch = async (url, init) => {
 			AFPDaily:    { Quota: 50000, Used: 0, ResetTime: 1787241600000 }
 		} });
 	}
+	if (s.includes('Action=GetCodingPlanUsage')) {
+		return veJson({ ResponseMetadata: {}, Result: {
+			Status: 'Running',
+			QuotaUsage: [
+				{ Level: 'session', Percent: 19, ResetTimestamp: 1787167230 },
+				{ Level: 'weekly', Percent: 74, ResetTimestamp: 1787500800 },
+				{ Level: 'monthly', Percent: 26, ResetTimestamp: 1789833599 }
+			]
+		} });
+	}
 	return veJson({ ResponseMetadata: { RequestId: 't' }, Result: {} });
 };
 try {
-	// AK-only -> row must NOT appear (needs both credentials)
+	// AK-only -> neither row may appear (each needs both credentials)
 	credentialMap = { VOLC_ACCESS_KEY: 'AKLTtest' };
 	veHandler = mount({});
 	const specAkOnly = await veHandler('specs', null, undefined);
-	check('A: volcengine hidden when only AK is configured', !specAkOnly.value.rows.some((r) => r.id === 'volcengine'));
+	check('A: volcengine rows hidden when only AK is configured', !specAkOnly.value.rows.some((r) => r.id === 'volcengine-agent' || r.id === 'volcengine-coding'));
 
-	// Both AK + SK -> row discovered, kind usage
+	// Both AK + SK -> BOTH rows discovered, each kind usage with own labels
 	credentialMap = { VOLC_ACCESS_KEY: 'AKLTtest', VOLC_SECRET_KEY: 'secretkey' };
 	veHandler = mount({});
 	const specBoth = await veHandler('specs', null, undefined);
-	const veSpec = specBoth.value.rows.find((r) => r.id === 'volcengine');
-	check('A: volcengine discovered when both AK and SK resolve', !!veSpec && veSpec.kind === 'usage' && veSpec.windowLabels?.rolling === '5h');
+	const agentSpec = specBoth.value.rows.find((r) => r.id === 'volcengine-agent');
+	const codingSpec = specBoth.value.rows.find((r) => r.id === 'volcengine-coding');
+	check('A: volcengine two rows discovered (agent + coding)', (() => {
+		return agentSpec?.kind === 'usage' && agentSpec.windowLabels?.rolling === '5h'
+			&& codingSpec?.kind === 'usage' && codingSpec.windowLabels?.rolling === '会话';
+	})());
 
-	// fetch-all -> GetAFPUsage response normalizes to 5h/weekly/monthly; AFPDaily skipped
+	// fetch-all: agent row parses GetAFPUsage; coding row parses GetCodingPlanUsage
 	veCalls = [];
 	veInits = [];
 	const veFetch = await veHandler('fetch-all', null, undefined);
-	const veRow = veFetch.value.rows.find((r) => r.id === 'volcengine');
-	check('A: volcengine Agent Plan -> 3 windows (AFPDaily skipped)', (() => {
-		const w = veRow?.view?.windows;
-		return veRow?.view?.kind === 'usage'
+	const agentRow = veFetch.value.rows.find((r) => r.id === 'volcengine-agent');
+	const codingRow = veFetch.value.rows.find((r) => r.id === 'volcengine-coding');
+	check('A: volcengine agent row -> Agent Plan 3 windows (AFPDaily skipped)', (() => {
+		const w = agentRow?.view?.windows;
+		return agentRow?.view?.kind === 'usage'
 			&& w?.rolling?.percent === 65
 			&& w?.weekly?.percent === 20
 			&& w?.monthly?.percent === 6
 			&& w?.daily === undefined
-			&& typeof w?.rolling?.resetsAt === 'string';
+			&& typeof w?.rolling?.resetsAt === 'string'
+			&& /Agent Plan/.test(agentRow?.view?.title ?? '');
 	})());
-	check('A: volcengine calls the signed OpenAPI with Action= and Region= in query', veCalls.some((u) => u.includes('Action=GetAFPUsage') && u.includes('Region=cn-beijing') && u.startsWith('https://open.volcengineapi.com/')));
+	check('A: volcengine coding row -> Coding Plan session/weekly/monthly', (() => {
+		const w = codingRow?.view?.windows;
+		return codingRow?.view?.kind === 'usage'
+			&& w?.rolling?.percent === 19
+			&& w?.weekly?.percent === 74
+			&& w?.monthly?.percent === 26
+			&& /Coding Plan/.test(codingRow?.view?.title ?? '');
+	})());
+	// No cross-fallback: each action is called exactly once and every call
+	// carries Region=cn-beijing on the OpenAPI host.
+	check('A: volcengine each row calls its own action only (no cross-fallback)',
+		veCalls.filter((u) => u.includes('Action=GetAFPUsage')).length === 1
+		&& veCalls.filter((u) => u.includes('Action=GetCodingPlanUsage')).length === 1
+		&& veCalls.every((u) => u.includes('Region=cn-beijing') && u.startsWith('https://open.volcengineapi.com/'))
+	);
 	check('A: volcengine request uses POST (not GET) with Authorization header', (() => {
-		const i = veCalls.findIndex((u) => u.includes('Action=GetAFPUsage'));
+		const i = veInits.findIndex((init) => init?.headers?.Authorization);
 		const init = i >= 0 ? veInits[i] : null;
 		return init?.method === 'POST'
 			&& typeof init?.headers?.Authorization === 'string'
@@ -322,14 +358,13 @@ try {
 	globalThis.fetch = realFetch;
 }
 
-// Volcengine: Coding Plan fallback when AFP returns no usable windows
-let veCpCalls = [];
+// Volcengine: only Coding Plan subscribed (Agent Plan returns no windows).
+// The agent row must report "not subscribed" and NOT fall back to Coding Plan.
 globalThis.fetch = async (url) => {
-	veCpCalls.push(String(url));
 	const s = String(url);
 	if (!s.includes('open.volcengineapi.com')) return { ok: false, status: 404, arrayBuffer: async () => new ArrayBuffer(0) };
 	if (s.includes('Action=GetAFPUsage')) {
-		// subscribed=false equivalent: empty Result (no quota fields)
+		// not subscribed: empty Result (PlanType present but no quota fields)
 		return veJson({ ResponseMetadata: {}, Result: { PlanType: 'medium' } });
 	}
 	if (s.includes('Action=GetCodingPlanUsage')) {
@@ -348,21 +383,24 @@ try {
 	credentialMap = { VOLC_ACCESS_KEY: 'AKLTtest', VOLC_SECRET_KEY: 'secretkey' };
 	const cpHandler = mount({});
 	const cpFetch = await cpHandler('fetch-all', null, undefined);
-	const cpRow = cpFetch.value.rows.find((r) => r.id === 'volcengine');
-	check('A: volcengine Coding Plan fallback parses session/weekly/monthly', (() => {
-		const w = cpRow?.view?.windows;
-		return cpRow?.view?.kind === 'usage'
+	const agentRow = cpFetch.value.rows.find((r) => r.id === 'volcengine-agent');
+	const codingRow = cpFetch.value.rows.find((r) => r.id === 'volcengine-coding');
+	check('A: volcengine agent row not-subscribed -> inline error, no Coding Plan fallback',
+		!!agentRow?.error && /Agent Plan/.test(agentRow.error) && agentRow.view === undefined
+	);
+	check('A: volcengine coding row still parses when agent is absent', (() => {
+		const w = codingRow?.view?.windows;
+		return codingRow?.view?.kind === 'usage'
 			&& w?.rolling?.percent === 0
 			&& w?.weekly?.percent === 2
 			&& w?.monthly?.percent === 1
 			&& w?.rolling?.resetsAt === undefined; // ResetTimestamp=-1 -> no reset
 	})());
-	check('A: volcengine fallback ordered GetAFPUsage then GetCodingPlanUsage', veCpCalls.filter((u) => u.includes('Action=GetAFPUsage')).length === 1 && veCpCalls.filter((u) => u.includes('Action=GetCodingPlanUsage')).length === 1 && veCpCalls.findIndex((u) => u.includes('GetAFPUsage')) < veCpCalls.findIndex((u) => u.includes('GetCodingPlanUsage')));
 } finally {
 	globalThis.fetch = realFetch;
 }
 
-// Volcengine: AK/SK auth error surfaces as per-row error (not throw)
+// Volcengine: AK/SK auth error surfaces as a per-row error on BOTH rows (not throw)
 globalThis.fetch = async (url) => {
 	if (String(url).includes('open.volcengineapi.com')) {
 		return veJson({ ResponseMetadata: { Error: { Code: 'SignatureDoesNotMatch', Message: 'bad secret' } } });
@@ -373,8 +411,12 @@ try {
 	credentialMap = { VOLC_ACCESS_KEY: 'AKLTbad', VOLC_SECRET_KEY: 'bad' };
 	const errHandler = mount({});
 	const errFetch = await errHandler('fetch-all', null, undefined);
-	const errRow = errFetch.value.rows.find((r) => r.id === 'volcengine');
-	check('A: volcengine auth error surfaces as per-row error with upstream code', !!errRow?.error && /SignatureDoesNotMatch/.test(errRow.error) && errRow.view === undefined);
+	const agentErr = errFetch.value.rows.find((r) => r.id === 'volcengine-agent');
+	const codingErr = errFetch.value.rows.find((r) => r.id === 'volcengine-coding');
+	check('A: volcengine auth error surfaces as per-row error on both rows with upstream code',
+		!!agentErr?.error && /SignatureDoesNotMatch/.test(agentErr.error) && agentErr.view === undefined
+		&& !!codingErr?.error && /SignatureDoesNotMatch/.test(codingErr.error) && codingErr.view === undefined
+	);
 } finally {
 	globalThis.fetch = realFetch;
 }
@@ -389,7 +431,8 @@ try {
 	let capturedAuth = null;
 	globalThis.fetch = async (url, init) => {
 		if (String(url).includes('open.volcengineapi.com')) {
-			capturedAuth = init?.headers?.Authorization ?? null;
+			// Agent row signs GetAFPUsage; capture that signature specifically.
+			if (String(url).includes('Action=GetAFPUsage')) capturedAuth = init?.headers?.Authorization ?? null;
 			return veJson({ ResponseMetadata: {}, Result: { AFPFiveHour: { Quota: 10, Used: 1 } } });
 		}
 		return { ok: false, status: 404, arrayBuffer: async () => new ArrayBuffer(0) };
@@ -413,7 +456,7 @@ try {
 	}
 }
 
-// Volcengine: response bodies above the 1 MiB ceiling are refused
+// Volcengine: response bodies above the 1 MiB ceiling are refused (both rows)
 {
 	globalThis.fetch = async (url) => {
 		if (String(url).includes('open.volcengineapi.com')) {
@@ -425,8 +468,12 @@ try {
 		credentialMap = { VOLC_ACCESS_KEY: 'AKLTtest', VOLC_SECRET_KEY: 'secretkey' };
 		const bigHandler = mount({});
 		const bigFetch = await bigHandler('fetch-all', null, undefined);
-		const bigRow = bigFetch.value.rows.find((r) => r.id === 'volcengine');
-		check('A: volcengine oversized body (>1 MiB) refused with per-row error', !!bigRow?.error && /exceeds/.test(bigRow.error) && bigRow.view === undefined);
+		const agentBig = bigFetch.value.rows.find((r) => r.id === 'volcengine-agent');
+		const codingBig = bigFetch.value.rows.find((r) => r.id === 'volcengine-coding');
+		check('A: volcengine oversized body (>1 MiB) refused on both rows',
+			!!agentBig?.error && /exceeds/.test(agentBig.error) && agentBig.view === undefined
+			&& !!codingBig?.error && /exceeds/.test(codingBig.error) && codingBig.view === undefined
+		);
 	} finally {
 		globalThis.fetch = realFetch;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1565,7 +1565,7 @@ function parseVolcengineCodingPlan(result: any): { kind: 'usage'; windows: Recor
 	}
 	if (Object.keys(windows).length === 0) return null;
 	const title = [
-		`5h: ${windows.rolling?.percent ?? '—'}%`,
+		`session: ${windows.rolling?.percent ?? '—'}%`,
 		`weekly: ${windows.weekly?.percent ?? '—'}%`,
 		`monthly: ${windows.monthly?.percent ?? '—'}%`
 	].join('\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -807,7 +807,8 @@ const FORMAT_META = {
 	'opencode-usage': { kind: 'usage' },
 	'zai-coding-quota': { kind: 'usage' },
 	'kimi-coding-usage': { kind: 'usage' },
-	'volcengine-usage': { kind: 'usage' },
+	'volcengine-agent-usage': { kind: 'usage' },
+	'volcengine-coding-usage': { kind: 'usage' },
 	'chatgpt-subscription': { kind: 'usage' }
 };
 
@@ -831,11 +832,17 @@ const CATALOG = [
 	{ id: 'zai', label: 'Z.AI GLM Coding', refs: ['ZAI_API_KEY'], endpoint: 'https://api.z.ai/api/monitor/usage/quota/limit', format: 'zai-coding-quota', windowLabels: { rolling: '5h', weekly: '周', monthly: '月' } },
 	{ id: 'kimi-coding', label: 'Kimi Coding', refs: ['KIMI_API_KEY'], endpoint: 'https://api.kimi.com/coding/v1/usages', format: 'kimi-coding-usage', windowLabels: { rolling: '5h', weekly: '周' } },
 	{ id: 'opencode-go', label: 'OpenCode Go', refs: ['OPENCODE_GO_API_KEY'], endpoint: 'https://opencode.ai/zen/go/v1/usage', format: 'opencode-usage' },
-	// Volcengine Ark (火山方舟): Agent Plan + Coding Plan usage via the
-	// OpenAPI control plane. Unlike every other catalog row this one
-	// authenticates with an AK/SK pair (signed, not Bearer) —
+	// Volcengine Ark (火山方舟) has two SEPARATE subscriptions, shown as two
+	// independent rows (like two providers) that share the same AK/SK pair.
+	// Unlike Bearer-key rows these authenticate with a signed AK/SK —
 	// `secretRefs` is the second credential and fetchRow signs the request.
-	{ id: 'volcengine', label: 'Volcengine Ark', refs: ['VOLC_ACCESS_KEY'], secretRefs: ['VOLC_SECRET_KEY'], endpoint: 'https://open.volcengineapi.com', format: 'volcengine-usage', windowLabels: { rolling: '5h', weekly: '周', monthly: '月' } },
+	//  • Agent Plan  -> GetAFPUsage      (5h rolling / weekly / monthly windows)
+	//  • Coding Plan -> GetCodingPlanUsage (session / weekly / monthly windows)
+	// Each row queries ONLY its own action; a plan the account has not
+	// subscribed to reports an inline "not subscribed" message instead of
+	// silently falling back to the other plan.
+	{ id: 'volcengine-agent', label: 'Volcengine Agent', refs: ['VOLC_ACCESS_KEY'], secretRefs: ['VOLC_SECRET_KEY'], endpoint: 'https://open.volcengineapi.com', format: 'volcengine-agent-usage', windowLabels: { rolling: '5h', weekly: '周', monthly: '月' } },
+	{ id: 'volcengine-coding', label: 'Volcengine Coding', refs: ['VOLC_ACCESS_KEY'], secretRefs: ['VOLC_SECRET_KEY'], endpoint: 'https://open.volcengineapi.com', format: 'volcengine-coding-usage', windowLabels: { rolling: '会话', weekly: '周', monthly: '月' } },
 	// ChatGPT subscription (Plus/Pro/Business via Codex OAuth). Unlike every
 	// other row this does NOT use ctx.credentials: tokens are read from
 	// ~/.codex/auth.json (written by `codex login`) and refreshed host-side.
@@ -1081,13 +1088,16 @@ const FORMATS = {
 		].filter(Boolean).join('\n');
 		return { kind: 'usage', windows, title };
 	},
-	// `volcengine-usage` is not dispatched through adaptRow: fetchRow handles
-	// the two-step GetAFPUsage → GetCodingPlanUsage fallback inline because
-	// the Volcengine auth path (signed AK/SK, not Bearer) and response
-	// envelopes differ from every other provider. The adapter exists so the
-	// format is registered in FORMATS/FORMAT_META for config validation.
-	'volcengine-usage': () => {
-		throw new Error('volcengine-usage is handled inline by fetchRow');
+	// `volcengine-agent-usage` / `volcengine-coding-usage` are not dispatched
+	// through adaptRow: fetchRow handles each inline because the Volcengine
+	// auth path (signed AK/SK, not Bearer) and response envelopes differ from
+	// every other provider. Each adapter exists only so the format is
+	// registered in FORMATS/FORMAT_META for config validation.
+	'volcengine-agent-usage': () => {
+		throw new Error('volcengine-agent-usage is handled inline by fetchRow');
+	},
+	'volcengine-coding-usage': () => {
+		throw new Error('volcengine-coding-usage is handled inline by fetchRow');
 	},
 	// chatgpt-subscription is dispatched inline in fetchRow because it uses
 	// an OAuth token from ~/.codex/auth.json (with refresh), not ctx.credentials.
@@ -1120,7 +1130,7 @@ export const Config = z.object({
 			z.const('moonshot-balance'), z.const('minimax-remains'), z.const('stepfun-accounts'),
 			z.const('xai-credits'), z.const('openai-billing'), z.const('zhipu-quota'),
 			z.const('opencode-usage'), z.const('zai-coding-quota'), z.const('kimi-coding-usage'),
-			z.const('volcengine-usage'), z.const('chatgpt-subscription')
+			z.const('volcengine-agent-usage'), z.const('volcengine-coding-usage'), z.const('chatgpt-subscription')
 		]).default('deepseek-balance'),
 		proxy: z.string(),
 		currency: z.string(),
@@ -1493,8 +1503,9 @@ function volcEpochToIso(v: unknown): string | undefined {
  * Parse a GetAFPUsage `Result` into rolling/weekly/monthly usage windows.
  * AFPDaily is intentionally skipped (hidden in the official console — its
  * quota is the legacy default, not an enforced limit). Quota<=0 marks an
- * unbound/unsubscribed window and is dropped, so an empty result means "no
- * active Agent Plan" and the caller falls through to Coding Plan.
+ * unbound/unsubscribed window and is dropped, so a null result means "no
+ * active Agent Plan" for the Agent row (it reports not-subscribed; the
+ * Coding Plan is a separate row queried independently, no fallback).
  */
 function parseVolcengineAFP(result: any): { kind: 'usage'; windows: Record<string, any>; title: string } | null {
 	const parseWin = (key: string) => {
@@ -1621,13 +1632,16 @@ async function fetchRow(ctx, provider, proxies, clientProxyUrl) {
 		}
 		// ── Volcengine Ark: AK/SK signed OpenAPI, not Bearer ──────
 		//
-		// Calls GetAFPUsage first (Agent Plan); if no quota windows
-		// come back (signature OK but no subscription), falls through
-		// to GetCodingPlanUsage. Per-row errors are surfaced inline;
-		// auth failures carry the upstream code in the message.
-		if (provider.format === 'volcengine-usage') {
+		// Two independent subscription rows share the same AK/SK:
+		//   volcengine-agent  -> GetAFPUsage      (Agent Plan)
+		//   volcengine-coding -> GetCodingPlanUsage (Coding Plan)
+		// Each row queries ONLY its own action — no fallback between the
+		// two, so a plan the account has not subscribed to reports an
+		// inline "not subscribed" message rather than showing the other
+		// plan's numbers. Auth failures carry the upstream code.
+		if (provider.format === 'volcengine-agent-usage' || provider.format === 'volcengine-coding-usage') {
 			if (!provider.secretCredential) {
-				return { id: provider.id, error: 'volcengine-usage requires both VOLC_ACCESS_KEY and VOLC_SECRET_KEY (only the AK was resolved)' };
+				return { id: provider.id, error: `${provider.format} requires both VOLC_ACCESS_KEY and VOLC_SECRET_KEY (only the AK was resolved)` };
 			}
 			const skHit = await ctx.credentials.resolve(provider.secretCredential);
 			if (!skHit || typeof skHit.value !== 'string' || skHit.value.length === 0) {
@@ -1645,23 +1659,27 @@ async function fetchRow(ctx, provider, proxies, clientProxyUrl) {
 				const m = /ark\.([a-z0-9-]+)\.volces\.com/.exec(provider.endpoint || '');
 				if (m) region = m[1];
 			}
+			const isAgent = provider.format === 'volcengine-agent-usage';
 			try {
-				const afpBody = await volcengineCall('GetAFPUsage', region, ak, sk, UPSTREAM_TIMEOUT_MS);
-				const afpResult = afpBody?.Result ?? afpBody;
-				const afpView = parseVolcengineAFP(afpResult);
-				if (afpView) {
-					const plan = afpResult?.PlanType ? `Agent Plan ${afpResult.PlanType}` : 'Agent Plan';
-					afpView.title = `plan: ${plan}\n` + afpView.title;
-					return { id: provider.id, view: afpView };
+				if (isAgent) {
+					const body = await volcengineCall('GetAFPUsage', region, ak, sk, UPSTREAM_TIMEOUT_MS);
+					const result = body?.Result ?? body;
+					const view = parseVolcengineAFP(result);
+					if (view) {
+						const plan = result?.PlanType ? `Agent Plan ${result.PlanType}` : 'Agent Plan';
+						view.title = `plan: ${plan}\n` + view.title;
+						return { id: provider.id, view };
+					}
+					return { id: provider.id, error: 'No active Volcengine Ark Agent Plan subscription (GetAFPUsage returned no quota windows)' };
 				}
-				const cpBody = await volcengineCall('GetCodingPlanUsage', region, ak, sk, UPSTREAM_TIMEOUT_MS);
-				const cpResult = cpBody?.Result ?? cpBody;
-				const cpView = parseVolcengineCodingPlan(cpResult);
-				if (cpView) {
-					cpView.title = 'plan: Coding Plan\n' + cpView.title;
-					return { id: provider.id, view: cpView };
+				const body = await volcengineCall('GetCodingPlanUsage', region, ak, sk, UPSTREAM_TIMEOUT_MS);
+				const result = body?.Result ?? body;
+				const view = parseVolcengineCodingPlan(result);
+				if (view) {
+					view.title = 'plan: Coding Plan\n' + view.title;
+					return { id: provider.id, view };
 				}
-				return { id: provider.id, error: 'No active Agent Plan or Coding Plan subscription' };
+				return { id: provider.id, error: 'No active Volcengine Ark Coding Plan subscription (GetCodingPlanUsage returned no quota windows)' };
 			} catch (ve) {
 				return { id: provider.id, error: String((ve && (ve as Error).message) || ve) };
 			}


### PR DESCRIPTION
## 改动概述

火山方舟（Volcengine Ark）实际上有**两个相互独立的订阅套餐**：**Agent Plan** 和 **Coding Plan**，一个账号可以**同时订阅两个**。此前插件只有一个「Volcengine Ark」行，逻辑是「先查 Agent Plan（`GetAFPUsage`），没有数据才回落查 Coding Plan（`GetCodingPlanUsage`）」的**二选一**——也就是说，同时订阅两个套餐的账号，**Coding Plan 的用量永远显示不出来**（Agent 行有数据后就不再查 Coding）。

本 PR 把它拆成**两个独立的行**，就像两个供应商一样**同时显示**，共享同一对 AK/SK：

| 行 | id | OpenAPI Action | 窗口 |
|---|---|---|---|
| Volcengine Agent | `volcengine-agent` | `GetAFPUsage` | 5h / 周 / 月 |
| Volcengine Coding | `volcengine-coding` | `GetCodingPlanUsage` | 会话（session）/ 周 / 月 |

**核心行为变化**：两行各自只查自己的接口，**不再互相回落**。订阅了哪个套餐，哪一行就有数据；未订阅的那一行显示独立的「未订阅」提示（可在 ⚙ 设置里隐藏），而不是错显示另一个套餐的数字。另外把 Coding 行的滚动窗口标签从「5h」改为更准确的「会话」（`GetCodingPlanUsage` 返回的是 session 级限额，不是 5 小时窗口）。

---

> 另外，关于**插件商店文案**：当前商店描述是「右下角额度胶囊：自动发现所有已配置 Key 的供应商（DeepSeek、OpenRouter、SiliconFlow、GLM、one-api/new-api、各类 Coding 套餐），显示余额或 5 小时/周滚动用量，支持按供应商设置可见性、告警阈值与代理。」——它没有体现出本插件最有差异化的两个能力。据我所知，目前多数用量/额度类插件都**不支持**这两项：
>
> - **火山方舟 Volcengine Ark 的 Agent Plan / Coding Plan 用量查询**（AK/SK 签名 OpenAPI，无需 Cookie）；
> - **ChatGPT Plus/Pro 订阅用户的接入引导与用量查询**（插件内设备码登录，或读取 Codex CLI 的 `~/.codex/auth.json`）。
>
> 建议在商店描述里补上类似一句（具体措辞由你定）：
>
> > 「支持火山方舟 Volcengine Ark 的 Agent Plan / Coding Plan 用量查询，并支持 ChatGPT Plus/Pro 订阅用户的一键登录引导与套餐用量查询。」
>
> 这样用户在商店里就能一眼看到这两个别家没有的能力。本 PR 只负责火山双套餐这部分；ChatGPT 订阅引导已在更早的 PR（#5）中合并。如果需要，我可以帮忙按插件商店的提交流程更新描述。

---

## 背景与动机

我本人就是「同时订阅了 Agent Plan 和 Coding Plan」的用户。合并 #4（火山接入）之后，面板上始终只出现一行火山用量（Agent Plan），Coding Plan 的会话/周/月用量无处可看——因为旧逻辑在 `GetAFPUsage` 返回有效窗口后就直接 return，根本不会再调 `GetCodingPlanUsage`。

这两个套餐是**独立计费、独立限额**的：Agent Plan 面向 Agent/自动化调用，Coding Plan 面向编码场景，窗口语义也不同（Agent 是 5 小时滚动窗，Coding 是 session 会话窗）。把它们当成两个独立供应商并列展示，既符合数据模型（面板里每一行就是一组 rolling/weekly/monthly 窗口，无法在一行里塞下两个套餐的六组数字），也和「一个账号可同时持有两个套餐」的实际情况一致。

## 实现细节

**宿主侧（`src/index.ts`）**
- 内置目录（catalog）把单个 `volcengine` 行替换为两行：`volcengine-agent`（`format: 'volcengine-agent-usage'`）与 `volcengine-coding`（`format: 'volcengine-coding-usage'`），两行的 `refs`/`secretRefs` 都是 `VOLC_ACCESS_KEY` / `VOLC_SECRET_KEY`，`endpoint` 相同。
- 自动发现逻辑无需改动：两行都要求 AK 与 SK **同时**可解析才上板（沿用原有「双凭据」探测），所以配好 AK/SK 后两行会一起出现。
- `FORMAT_META`、`FORMATS`（内联适配器桩）、zod 的 `format` 枚举都登记了两个新 format id。
- `fetchRow` 的火山分支重构：按 `format` 分流——`volcengine-agent-usage` 只调 `GetAFPUsage` 并走 `parseVolcengineAFP`；`volcengine-coding-usage` 只调 `GetCodingPlanUsage` 并走 `parseVolcengineCodingPlan`。**删除了两步回落**。解析函数（含 `AFPDaily` 跳过、毫秒/秒时间戳兼容、`ResetTimestamp=-1` 不产生 resetsAt 等）完全复用，未改动。
- 未订阅时返回明确的单行错误：`No active Volcengine Ark Agent/Coding Plan subscription (...)`，鉴权失败（如 `SignatureDoesNotMatch`）仍在两行各自携带上游错误码上报。

**客户端（`src/client.ts`）**
- **无需改动**。客户端按 `specs` 通用渲染每个 usage 行，不感知火山；两行会和其它供应商一样各自渲染。

**文档（`README.md` / `README.zh.md`）**
- 内置供应商表：火山一行拆为 Agent / Coding 两行，注明各自的 Action 与窗口；
- 接入教程的排错段更新为两行模型（订阅哪个哪个有数据、未订阅那行提示、可在设置隐藏）；
- format 适配器表把 `volcengine-usage` 拆为 `volcengine-agent-usage` / `volcengine-coding-usage` 两行说明；
- 配置字段表（`secretCredential` / `region`）引用的 format id 同步更新；
- 中英文更新日志各加一条。

**测试（`scripts/test-page-script.mjs`）**
- 「仅配置 AK」时两行都不上板；「AK+SK」时两行都被发现，且各自窗口标签正确（Agent rolling=「5h」、Coding rolling=「会话」）；
- 两个套餐都有数据时：Agent 行解析 `GetAFPUsage`（65/20/6，AFPDaily 丢弃），Coding 行解析 `GetCodingPlanUsage`（19/74/26），且 `GetAFPUsage` 与 `GetCodingPlanUsage` 各只被调用一次、**无交叉回落**；
- 「只订 Coding」场景：Agent 行返回内联「未订阅」错误且**不回落**到 Coding，Coding 行仍正常解析；
- 鉴权失败时两行各自上报含 `SignatureDoesNotMatch` 的单行错误；
- 签名金标准向量（golden vector，针对 `GetAFPUsage`）、>1 MiB 响应体拒绝（两行都拒绝）、HMAC-SHA256 签名形态等既有安全断言全部保留并适配两行。

## 安全说明

- 与既有火山实现一致：AK/SK 只在宿主侧用于 HMAC-SHA256 签名，令牌/凭据绝不下发浏览器；客户端经 `rowSpec()` 只拿到展示字段（id/label/kind/窗口标签/阈值），不接触凭据、端点或路径。
- 两行共用同一对 AK/SK，不引入新的凭据存储或权限；所需权限仍是只读的 `ArkReadOnlyAccess`（`GetAFPUsage` / `GetCodingPlanUsage` 都是只读动作）。

## 兼容性 / 迁移

- 火山功能是在 #4 合并、但尚未随正式版商店发布（商店仍是 0.8）的能力，旧的 `volcengine` 行 id 几乎没有用户在自定义 `catalog` 里依赖；本 PR 直接用两个新 id 替换旧 id。若维护者更希望保留 `volcengine-usage` 作为兼容别名，我可以补上。
- 对「只订一个套餐」的用户：未订阅的那行会显示一条「未订阅」提示（与其它取数失败行一样在 ⚙ 设置里可隐藏）。这比旧行为（永远看不到另一个套餐）信息更完整；如果你更希望未订阅的行**完全不出现**，需要在自动发现阶段多发一次探测请求，我也可以按那个方向调整——但那会让首屏多两次串行 OpenAPI 调用，故当前选择了「上板 + 行内友好提示」。

## 测试

```
npm run build   # tsc 通过
node scripts/test-page-script.mjs   # All dual-face checks passed.
```

火山相关 12 条断言全部通过，其余既有断言无回归。

---

感谢维护！火山 Ark 的接入（#4）做得很扎实，这个 PR 只是在它基础上把「两个套餐」这件事补完整。